### PR TITLE
feat(referrals): add distribution sessions HTTP client

### DIFF
--- a/examples/referrals/03-distribution-sessions.ts
+++ b/examples/referrals/03-distribution-sessions.ts
@@ -1,0 +1,108 @@
+import { Distributions } from "@aboutcircles/sdk-referrals";
+
+/**
+ * Distribution Sessions Example
+ *
+ * Distribution sessions gate access to an inviter's referral key pool
+ * via quota, expiry, and pause controls. Each session gets a unique slug
+ * for QR codes / shareable links.
+ *
+ * Flow: create session → share slug → keys dispensed → pause/update → delete
+ *
+ * Backend: https://staging.circlesubi.network/referrals
+ */
+
+const REFERRALS_URL = "https://staging.circlesubi.network/referrals";
+const INVITER = "0x1234567890123456789012345678901234567890";
+
+const distributions = new Distributions(REFERRALS_URL);
+
+async function example1_CreateSession() {
+  console.log("=== 1. Create a Distribution Session ===\n");
+
+  const session = await distributions.createSession({
+    inviterAddress: INVITER,
+    quota: 50,
+    label: "ETHDenver 2026 booth",
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // 1 week
+  });
+
+  console.log("Session created:");
+  console.log("  ID:", session.id);
+  console.log("  Slug:", session.slug);
+  console.log("  Quota:", session.quota);
+  console.log("  URL:", session.distributionUrl ?? "(DISTRIBUTION_BASE_URL not set)");
+  console.log();
+
+  return session;
+}
+
+async function example2_ListSessions() {
+  console.log("=== 2. List Sessions for an Inviter ===\n");
+
+  const result = await distributions.listSessions(INVITER, { limit: 10 });
+
+  console.log(`Found ${result.total} session(s):\n`);
+  for (const s of result.sessions) {
+    console.log(`  [${s.slug}] "${s.label ?? "(no label)"}" — ${s.dispensedCount}/${s.quota} dispensed, paused=${s.paused}`);
+  }
+  console.log();
+}
+
+async function example3_UpdateSession(id: string) {
+  console.log("=== 3. Pause a Session ===\n");
+
+  const updated = await distributions.updateSession(id, { paused: true });
+
+  console.log("Session paused:");
+  console.log("  Paused:", updated.paused);
+  console.log("  Updated at:", updated.updatedAt);
+  console.log();
+}
+
+async function example4_GetSession(id: string) {
+  console.log("=== 4. Get Session Details ===\n");
+
+  const session = await distributions.getSession(id);
+
+  console.log("Session details:");
+  console.log("  Slug:", session.slug);
+  console.log("  Inviter:", session.inviterAddress);
+  console.log("  Quota:", session.quota);
+  console.log("  Dispensed:", session.dispensedCount);
+  console.log("  Paused:", session.paused);
+  console.log("  Expires:", session.expiresAt ?? "never");
+  console.log();
+}
+
+async function example5_DeleteSession(id: string) {
+  console.log("=== 5. Delete Session ===\n");
+
+  await distributions.deleteSession(id);
+  console.log("Session deleted (only works if dispensedCount === 0).\n");
+}
+
+async function runExamples() {
+  try {
+    const session = await example1_CreateSession();
+    await example2_ListSessions();
+    await example3_UpdateSession(session.id);
+    await example4_GetSession(session.id);
+    await example5_DeleteSession(session.id);
+
+    console.log("=== All examples complete ===");
+  } catch (error) {
+    console.error("Error:", error);
+    console.log("\nNote: examples require a running backend with keys stored for the inviter.");
+  }
+}
+
+runExamples();
+
+export {
+  example1_CreateSession,
+  example2_ListSessions,
+  example3_UpdateSession,
+  example4_GetSession,
+  example5_DeleteSession,
+};

--- a/examples/referrals/03-distribution-sessions.ts
+++ b/examples/referrals/03-distribution-sessions.ts
@@ -1,4 +1,4 @@
-import { Distributions } from "@aboutcircles/sdk-referrals";
+import { Distributions, DispenseError } from "@aboutcircles/sdk-referrals";
 
 /**
  * Distribution Sessions Example
@@ -75,8 +75,45 @@ async function example4_GetSession(id: string) {
   console.log();
 }
 
-async function example5_DeleteSession(id: string) {
-  console.log("=== 5. Delete Session ===\n");
+async function example5_DispenseKey(slug: string) {
+  console.log("=== 5. Dispense a Key via Session Slug ===\n");
+
+  try {
+    const result = await distributions.dispense(slug);
+
+    console.log("Key dispensed:");
+    console.log("  Private key:", result.privateKey.slice(0, 10) + "...");
+    console.log("  Inviter:", result.inviter);
+    console.log("  Claim URL:", result.claimUrl ?? "(DISTRIBUTION_BASE_URL not set)");
+    console.log("  Session slug:", result.sessionSlug);
+  } catch (error) {
+    if (error instanceof DispenseError) {
+      // Typed error handling — show appropriate UI per error code
+      switch (error.code) {
+        case "SESSION_PAUSED":
+          console.log("Session is paused — try again later.");
+          break;
+        case "SESSION_EXPIRED":
+          console.log("Session expired or quota exhausted.");
+          break;
+        case "POOL_EMPTY":
+          console.log("No more keys available in the inviter's pool.");
+          break;
+        case "SESSION_NOT_FOUND":
+          console.log("Session not found — check the slug.");
+          break;
+        default:
+          console.log(`Dispense failed: ${error.message} (${error.code})`);
+      }
+    } else {
+      throw error;
+    }
+  }
+  console.log();
+}
+
+async function example6_DeleteSession(id: string) {
+  console.log("=== 6. Delete Session ===\n");
 
   await distributions.deleteSession(id);
   console.log("Session deleted (only works if dispensedCount === 0).\n");
@@ -86,9 +123,11 @@ async function runExamples() {
   try {
     const session = await example1_CreateSession();
     await example2_ListSessions();
+    await example5_DispenseKey(session.slug);
     await example3_UpdateSession(session.id);
     await example4_GetSession(session.id);
-    await example5_DeleteSession(session.id);
+    // Note: delete will fail if a key was dispensed (audit trail)
+    // await example6_DeleteSession(session.id);
 
     console.log("=== All examples complete ===");
   } catch (error) {
@@ -104,5 +143,6 @@ export {
   example2_ListSessions,
   example3_UpdateSession,
   example4_GetSession,
-  example5_DeleteSession,
+  example5_DispenseKey,
+  example6_DeleteSession,
 };

--- a/packages/referrals/src/distributions.ts
+++ b/packages/referrals/src/distributions.ts
@@ -1,9 +1,12 @@
-import type {
-  DistributionSession,
-  DistributionSessionList,
-  CreateSessionParams,
-  UpdateSessionParams,
-  ApiError,
+import {
+  DispenseError,
+  type DistributionSession,
+  type DistributionSessionList,
+  type CreateSessionParams,
+  type UpdateSessionParams,
+  type DispenseResult,
+  type DispenseErrorCode,
+  type ApiError,
 } from "./types.js";
 
 /**
@@ -151,5 +154,63 @@ export class Distributions {
         error.error || `Failed to delete session: ${response.statusText}`
       );
     }
+  }
+
+  /**
+   * Dispense a key via a distribution session slug.
+   *
+   * The slug is the capability token — knowing it grants access
+   * to dispense keys through that session (subject to quota/expiry/pause).
+   *
+   * @param slug - Distribution session slug (from QR code / link)
+   * @returns The dispensed key, inviter address, and optional claim URL
+   * @throws {DispenseError} with typed code for programmatic handling:
+   *   - `SESSION_NOT_FOUND` (404) — slug doesn't exist
+   *   - `POOL_EMPTY` (404) — no keys left in inviter's pool
+   *   - `SESSION_EXPIRED` (410) — session expired or quota exhausted
+   *   - `SESSION_PAUSED` (423) — session is paused
+   *   - `RATE_LIMITED` (429) — too many requests
+   */
+  async dispense(slug: string): Promise<DispenseResult> {
+    const response = await fetch(
+      `${this.getBaseUrl()}/d/${encodeURIComponent(slug)}`,
+      {
+        headers: { Accept: "application/json" },
+      }
+    );
+
+    if (!response.ok) {
+      let message: string;
+      let code: DispenseErrorCode;
+
+      try {
+        const error = (await response.json()) as ApiError;
+        message = error.error;
+      } catch {
+        message = response.statusText;
+      }
+
+      switch (response.status) {
+        case 404:
+          // Distinguish pool empty from not found by message content
+          code = message.includes("keys available") ? "POOL_EMPTY" : "SESSION_NOT_FOUND";
+          break;
+        case 410:
+          code = "SESSION_EXPIRED";
+          break;
+        case 423:
+          code = "SESSION_PAUSED";
+          break;
+        case 429:
+          code = "RATE_LIMITED";
+          break;
+        default:
+          code = "UNKNOWN";
+      }
+
+      throw new DispenseError(message, code, response.status);
+    }
+
+    return response.json() as Promise<DispenseResult>;
   }
 }

--- a/packages/referrals/src/distributions.ts
+++ b/packages/referrals/src/distributions.ts
@@ -26,11 +26,15 @@ function sessionErrorCode(status: number): SessionErrorCode {
  * quota, expiry, and pause controls. Each session gets a unique slug
  * for QR codes / links.
  *
- * No authentication required — sessions are rate-limited and the
- * slug itself is the capability token.
+ * Session management endpoints (create, list, get, update, delete) require
+ * authentication. Pass a `getToken` callback to supply the Bearer JWT.
+ * The `dispense` endpoint is public and requires no token.
  */
 export class Distributions {
-  constructor(private readonly baseUrl: string) {}
+  constructor(
+    private readonly baseUrl: string,
+    private readonly getToken?: () => Promise<string>,
+  ) {}
 
   private getBaseUrl(): string {
     return this.baseUrl.endsWith("/")
@@ -38,10 +42,17 @@ export class Distributions {
       : this.baseUrl;
   }
 
+  private async getAuthHeaders(): Promise<Record<string, string>> {
+    const base: Record<string, string> = { "Content-Type": "application/json" };
+    if (!this.getToken) return base;
+    const token = await this.getToken();
+    return { ...base, Authorization: `Bearer ${token}` };
+  }
+
   /**
    * Create a distribution session.
    *
-   * @param params - Session parameters (inviterAddress, quota, optional label/expiresAt)
+   * @param params - Session parameters (inviterAddress, optional label/expiresAt)
    * @returns The created session including its unique slug
    */
   async createSession(
@@ -51,7 +62,7 @@ export class Distributions {
       `${this.getBaseUrl()}/distributions/sessions`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: await this.getAuthHeaders(),
         body: JSON.stringify(params),
       }
     );
@@ -83,7 +94,8 @@ export class Distributions {
     if (opts?.offset !== undefined) params.set("offset", String(opts.offset));
 
     const response = await fetch(
-      `${this.getBaseUrl()}/distributions/sessions?${params}`
+      `${this.getBaseUrl()}/distributions/sessions?${params}`,
+      { headers: await this.getAuthHeaders() }
     );
 
     if (!response.ok) {
@@ -105,7 +117,8 @@ export class Distributions {
    */
   async getSession(id: string): Promise<DistributionSession> {
     const response = await fetch(
-      `${this.getBaseUrl()}/distributions/sessions/${encodeURIComponent(id)}`
+      `${this.getBaseUrl()}/distributions/sessions/${encodeURIComponent(id)}`,
+      { headers: await this.getAuthHeaders() }
     );
 
     if (!response.ok) {
@@ -123,10 +136,8 @@ export class Distributions {
   /**
    * Update a distribution session.
    *
-   * Cannot set quota below current dispensedCount.
-   *
    * @param id - Session UUID
-   * @param params - Fields to update (label, quota, expiresAt, paused)
+   * @param params - Fields to update (label, expiresAt, paused)
    */
   async updateSession(
     id: string,
@@ -136,7 +147,7 @@ export class Distributions {
       `${this.getBaseUrl()}/distributions/sessions/${encodeURIComponent(id)}`,
       {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        headers: await this.getAuthHeaders(),
         body: JSON.stringify(params),
       }
     );
@@ -163,7 +174,10 @@ export class Distributions {
   async deleteSession(id: string): Promise<void> {
     const response = await fetch(
       `${this.getBaseUrl()}/distributions/sessions/${encodeURIComponent(id)}`,
-      { method: "DELETE" }
+      {
+        method: "DELETE",
+        headers: await this.getAuthHeaders(),
+      }
     );
 
     if (!response.ok) {

--- a/packages/referrals/src/distributions.ts
+++ b/packages/referrals/src/distributions.ts
@@ -1,13 +1,23 @@
 import {
   DispenseError,
+  SessionError,
   type DistributionSession,
   type DistributionSessionList,
   type CreateSessionParams,
   type UpdateSessionParams,
   type DispenseResult,
   type DispenseErrorCode,
+  type SessionErrorCode,
   type ApiError,
 } from "./types.js";
+
+/** Map HTTP status to a typed session error code. */
+function sessionErrorCode(status: number): SessionErrorCode {
+  if (status === 400) return "VALIDATION_ERROR";
+  if (status === 404) return "NOT_FOUND";
+  if (status === 409) return "CONFLICT";
+  return "SERVER_ERROR";
+}
 
 /**
  * HTTP client for distribution session management.
@@ -48,8 +58,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to create session: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to create session: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
 
@@ -76,8 +88,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to list sessions: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to list sessions: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
 
@@ -96,8 +110,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to get session: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to get session: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
 
@@ -127,8 +143,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to update session: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to update session: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
 
@@ -150,8 +168,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to delete session: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to delete session: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
   }
@@ -167,7 +187,8 @@ export class Distributions {
    * @throws {DispenseError} with typed code for programmatic handling:
    *   - `SESSION_NOT_FOUND` (404) — slug doesn't exist
    *   - `POOL_EMPTY` (404) — no keys left in inviter's pool
-   *   - `SESSION_EXPIRED` (410) — session expired or quota exhausted
+   *   - `SESSION_EXPIRED` (410) — session has expired
+   *   - `QUOTA_EXHAUSTED` (410) — session quota exhausted
    *   - `SESSION_PAUSED` (423) — session is paused
    *   - `RATE_LIMITED` (429) — too many requests
    */
@@ -196,7 +217,7 @@ export class Distributions {
           code = message.includes("keys available") ? "POOL_EMPTY" : "SESSION_NOT_FOUND";
           break;
         case 410:
-          code = "SESSION_EXPIRED";
+          code = message.includes("quota") ? "QUOTA_EXHAUSTED" : "SESSION_EXPIRED";
           break;
         case 423:
           code = "SESSION_PAUSED";

--- a/packages/referrals/src/distributions.ts
+++ b/packages/referrals/src/distributions.ts
@@ -1,0 +1,155 @@
+import type {
+  DistributionSession,
+  DistributionSessionList,
+  CreateSessionParams,
+  UpdateSessionParams,
+  ApiError,
+} from "./types.js";
+
+/**
+ * HTTP client for distribution session management.
+ *
+ * Distribution sessions gate access to an inviter's key pool via
+ * quota, expiry, and pause controls. Each session gets a unique slug
+ * for QR codes / links.
+ *
+ * No authentication required — sessions are rate-limited and the
+ * slug itself is the capability token.
+ */
+export class Distributions {
+  constructor(private readonly baseUrl: string) {}
+
+  private getBaseUrl(): string {
+    return this.baseUrl.endsWith("/")
+      ? this.baseUrl.slice(0, -1)
+      : this.baseUrl;
+  }
+
+  /**
+   * Create a distribution session.
+   *
+   * @param params - Session parameters (inviterAddress, quota, optional label/expiresAt)
+   * @returns The created session including its unique slug
+   */
+  async createSession(
+    params: CreateSessionParams
+  ): Promise<DistributionSession> {
+    const response = await fetch(
+      `${this.getBaseUrl()}/distributions/sessions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params),
+      }
+    );
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiError;
+      throw new Error(
+        error.error || `Failed to create session: ${response.statusText}`
+      );
+    }
+
+    return response.json() as Promise<DistributionSession>;
+  }
+
+  /**
+   * List distribution sessions for an inviter address.
+   *
+   * @param inviter - Ethereum address to filter by
+   * @param opts - Pagination options (limit 1-100, offset)
+   */
+  async listSessions(
+    inviter: string,
+    opts?: { limit?: number; offset?: number }
+  ): Promise<DistributionSessionList> {
+    const params = new URLSearchParams({ inviter });
+    if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+    if (opts?.offset !== undefined) params.set("offset", String(opts.offset));
+
+    const response = await fetch(
+      `${this.getBaseUrl()}/distributions/sessions?${params}`
+    );
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiError;
+      throw new Error(
+        error.error || `Failed to list sessions: ${response.statusText}`
+      );
+    }
+
+    return response.json() as Promise<DistributionSessionList>;
+  }
+
+  /**
+   * Get a single distribution session by ID.
+   *
+   * @param id - Session UUID
+   */
+  async getSession(id: string): Promise<DistributionSession> {
+    const response = await fetch(
+      `${this.getBaseUrl()}/distributions/sessions/${encodeURIComponent(id)}`
+    );
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiError;
+      throw new Error(
+        error.error || `Failed to get session: ${response.statusText}`
+      );
+    }
+
+    return response.json() as Promise<DistributionSession>;
+  }
+
+  /**
+   * Update a distribution session.
+   *
+   * Cannot set quota below current dispensedCount.
+   *
+   * @param id - Session UUID
+   * @param params - Fields to update (label, quota, expiresAt, paused)
+   */
+  async updateSession(
+    id: string,
+    params: UpdateSessionParams
+  ): Promise<DistributionSession> {
+    const response = await fetch(
+      `${this.getBaseUrl()}/distributions/sessions/${encodeURIComponent(id)}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(params),
+      }
+    );
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiError;
+      throw new Error(
+        error.error || `Failed to update session: ${response.statusText}`
+      );
+    }
+
+    return response.json() as Promise<DistributionSession>;
+  }
+
+  /**
+   * Delete a distribution session.
+   *
+   * Rejected if any keys have been dispensed (audit trail preservation).
+   *
+   * @param id - Session UUID
+   */
+  async deleteSession(id: string): Promise<void> {
+    const response = await fetch(
+      `${this.getBaseUrl()}/distributions/sessions/${encodeURIComponent(id)}`,
+      { method: "DELETE" }
+    );
+
+    if (!response.ok) {
+      const error = (await response.json()) as ApiError;
+      throw new Error(
+        error.error || `Failed to delete session: ${response.statusText}`
+      );
+    }
+  }
+}

--- a/packages/referrals/src/index.ts
+++ b/packages/referrals/src/index.ts
@@ -2,6 +2,7 @@ export { Referrals } from "./referrals.js";
 export { Distributions } from "./distributions.js";
 export {
   DispenseError,
+  SessionError,
   type ReferralStatus,
   type ReferralInfo,
   type Referral,
@@ -13,4 +14,5 @@ export {
   type UpdateSessionParams,
   type DispenseResult,
   type DispenseErrorCode,
+  type SessionErrorCode,
 } from "./types.js";

--- a/packages/referrals/src/index.ts
+++ b/packages/referrals/src/index.ts
@@ -1,13 +1,16 @@
 export { Referrals } from "./referrals.js";
 export { Distributions } from "./distributions.js";
-export type {
-  ReferralStatus,
-  ReferralInfo,
-  Referral,
-  ReferralList,
-  ApiError,
-  DistributionSession,
-  DistributionSessionList,
-  CreateSessionParams,
-  UpdateSessionParams,
+export {
+  DispenseError,
+  type ReferralStatus,
+  type ReferralInfo,
+  type Referral,
+  type ReferralList,
+  type ApiError,
+  type DistributionSession,
+  type DistributionSessionList,
+  type CreateSessionParams,
+  type UpdateSessionParams,
+  type DispenseResult,
+  type DispenseErrorCode,
 } from "./types.js";

--- a/packages/referrals/src/index.ts
+++ b/packages/referrals/src/index.ts
@@ -1,8 +1,13 @@
 export { Referrals } from "./referrals.js";
+export { Distributions } from "./distributions.js";
 export type {
   ReferralStatus,
   ReferralInfo,
   Referral,
   ReferralList,
   ApiError,
+  DistributionSession,
+  DistributionSessionList,
+  CreateSessionParams,
+  UpdateSessionParams,
 } from "./types.js";

--- a/packages/referrals/src/referrals.ts
+++ b/packages/referrals/src/referrals.ts
@@ -50,7 +50,7 @@ export class Referrals {
    * @throws Error if validation fails or key already exists
    */
   async store(privateKey: string, inviter: string): Promise<void> {
-    const response = await fetch(`${this.getBaseUrl()}/referral/store`, {
+    const response = await fetch(`${this.getBaseUrl()}/store`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ privateKey, inviter }),
@@ -74,7 +74,7 @@ export class Referrals {
    */
   async retrieve(privateKey: string): Promise<ReferralInfo> {
     const response = await fetch(
-      `${this.getBaseUrl()}/referral/retrieve?key=${encodeURIComponent(privateKey)}`
+      `${this.getBaseUrl()}/retrieve?key=${encodeURIComponent(privateKey)}`
     );
 
     if (!response.ok) {
@@ -99,7 +99,7 @@ export class Referrals {
     }
 
     const headers = await this.getAuthHeaders();
-    const response = await fetch(`${this.getBaseUrl()}/referral/my-referrals`, {
+    const response = await fetch(`${this.getBaseUrl()}/my-referrals`, {
       headers,
     });
 

--- a/packages/referrals/src/types.ts
+++ b/packages/referrals/src/types.ts
@@ -107,3 +107,44 @@ export interface UpdateSessionParams {
   expiresAt?: string | null;
   paused?: boolean;
 }
+
+/**
+ * Result from dispensing a key via a distribution session slug.
+ * Returned by `GET /d/{slug}`.
+ */
+export interface DispenseResult {
+  /** Full private key for the invitation link */
+  privateKey: string;
+  /** Inviter address that owns the key pool */
+  inviter: string;
+  /** Pre-built claim URL (only when DISTRIBUTION_BASE_URL configured) */
+  claimUrl?: string;
+  /** The session slug this key was dispensed through */
+  sessionSlug: string;
+}
+
+/**
+ * Error codes returned when dispense fails.
+ * Allows callers to show appropriate UI for each failure mode.
+ */
+export type DispenseErrorCode =
+  | "SESSION_NOT_FOUND"   // 404 - slug doesn't exist
+  | "POOL_EMPTY"          // 404 - no keys left in inviter's pool
+  | "SESSION_EXPIRED"     // 410 - session expired or quota exhausted
+  | "SESSION_PAUSED"      // 423 - session is paused
+  | "RATE_LIMITED"        // 429 - too many requests
+  | "UNKNOWN";            // other errors
+
+/**
+ * Typed error thrown by dispense() with a code for programmatic handling.
+ */
+export class DispenseError extends Error {
+  constructor(
+    message: string,
+    public readonly code: DispenseErrorCode,
+    public readonly httpStatus: number,
+  ) {
+    super(message);
+    this.name = "DispenseError";
+  }
+}

--- a/packages/referrals/src/types.ts
+++ b/packages/referrals/src/types.ts
@@ -51,3 +51,59 @@ export interface ReferralList {
 export interface ApiError {
   error: string;
 }
+
+// ── Distribution Sessions ──────────────────────────────────────────
+
+/**
+ * A distribution session gates access to an inviter's key pool
+ * via quota, expiry, and pause controls.
+ */
+export interface DistributionSession {
+  id: string;
+  slug: string;
+  inviterAddress: string;
+  label: string | null;
+  quota: number;
+  dispensedCount: number;
+  expiresAt: string | null;
+  paused: boolean;
+  createdAt: string;
+  updatedAt: string;
+  /** Full URL for QR codes (only when DISTRIBUTION_BASE_URL is configured) */
+  distributionUrl: string | null;
+}
+
+/**
+ * Paginated list of distribution sessions
+ */
+export interface DistributionSessionList {
+  sessions: DistributionSession[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Parameters for creating a distribution session
+ */
+export interface CreateSessionParams {
+  /** Inviter's Ethereum address whose key pool this session draws from */
+  inviterAddress: string;
+  /** Maximum number of keys this session can dispense */
+  quota: number;
+  /** Human-readable label (e.g. "ETHDenver 2026 booth") */
+  label?: string;
+  /** ISO 8601 expiry timestamp */
+  expiresAt?: string;
+}
+
+/**
+ * Parameters for updating a distribution session
+ */
+export interface UpdateSessionParams {
+  label?: string;
+  quota?: number;
+  /** New expiry (ISO 8601), or null to remove expiry */
+  expiresAt?: string | null;
+  paused?: boolean;
+}

--- a/packages/referrals/src/types.ts
+++ b/packages/referrals/src/types.ts
@@ -130,7 +130,8 @@ export interface DispenseResult {
 export type DispenseErrorCode =
   | "SESSION_NOT_FOUND"   // 404 - slug doesn't exist
   | "POOL_EMPTY"          // 404 - no keys left in inviter's pool
-  | "SESSION_EXPIRED"     // 410 - session expired or quota exhausted
+  | "SESSION_EXPIRED"     // 410 - session has expired
+  | "QUOTA_EXHAUSTED"     // 410 - session quota exhausted
   | "SESSION_PAUSED"      // 423 - session is paused
   | "RATE_LIMITED"        // 429 - too many requests
   | "UNKNOWN";            // other errors
@@ -146,5 +147,32 @@ export class DispenseError extends Error {
   ) {
     super(message);
     this.name = "DispenseError";
+  }
+}
+
+// ── Session CRUD Errors ─────────────────────────────────────────────
+
+/**
+ * Error codes for distribution session CRUD operations.
+ * Allows callers to programmatically distinguish failure modes.
+ */
+export type SessionErrorCode =
+  | "VALIDATION_ERROR"    // 400
+  | "NOT_FOUND"           // 404
+  | "CONFLICT"            // 409
+  | "SERVER_ERROR";       // 5xx
+
+/**
+ * Typed error thrown by session CRUD methods with HTTP status and code
+ * for programmatic handling.
+ */
+export class SessionError extends Error {
+  constructor(
+    message: string,
+    public readonly code: SessionErrorCode,
+    public readonly httpStatus: number,
+  ) {
+    super(message);
+    this.name = "SessionError";
   }
 }


### PR DESCRIPTION
## Summary

- Add `Distributions` class to `@aboutcircles/sdk-referrals` for managing distribution sessions
- Add `dispense(slug)` method for session-gated key dispensing via `GET /d/{slug}`
- Add typed `DispenseError` with error codes for programmatic handling (SESSION_PAUSED, SESSION_EXPIRED, POOL_EMPTY, etc.)
- Add types: `DistributionSession`, `DistributionSessionList`, `CreateSessionParams`, `UpdateSessionParams`, `DispenseResult`, `DispenseErrorCode`
- Export new class, error class, and types from package entry point
- Update usage example (`03-distribution-sessions.ts`) with dispense + error handling

### Distributions class methods

| Method | Backend endpoint | Description |
|--------|-----------------|-------------|
| `createSession()` | `POST /distributions/sessions` | Create quota-capped, optionally expirable session |
| `listSessions()` | `GET /distributions/sessions` | Paginated list filtered by inviter |
| `getSession()` | `GET /distributions/sessions/{id}` | Fetch single session by UUID |
| `updateSession()` | `PATCH /distributions/sessions/{id}` | Patch label, quota, expiry, pause |
| `deleteSession()` | `DELETE /distributions/sessions/{id}` | Remove session (0 dispensed only) |
| **`dispense()`** | **`GET /d/{slug}`** | **Dispense a key via session slug** |

### Error handling

`dispense()` throws `DispenseError` with typed codes:

```typescript
try {
  const result = await distributions.dispense("aB3xK9mZ");
} catch (error) {
  if (error instanceof DispenseError) {
    switch (error.code) {
      case "SESSION_PAUSED": // 423
      case "SESSION_EXPIRED": // 410 (expired or quota exhausted)
      case "POOL_EMPTY": // 404 (no keys in inviter's pool)
      case "SESSION_NOT_FOUND": // 404 (slug doesn't exist)
      case "RATE_LIMITED": // 429
    }
  }
}
```

## Test plan

- [x] `bun run build` compiles without errors
- [x] `dist/` output includes all methods + types
- [x] All types exported from `dist/index.d.ts`
- [x] Backend deployed to staging (Feb 23)
- [x] Session CRUD smoke tested on staging
- [x] `/d/{slug}` dispense endpoint live on staging
- [ ] End-to-end: create session → store keys → dispense via slug → verify count