### PR TITLE
fix(referrals): correct URL paths, typed errors, 410 distinction

### DIFF
--- a/packages/referrals/src/distributions.ts
+++ b/packages/referrals/src/distributions.ts
@@ -1,13 +1,23 @@
 import {
   DispenseError,
+  SessionError,
   type DistributionSession,
   type DistributionSessionList,
   type CreateSessionParams,
   type UpdateSessionParams,
   type DispenseResult,
   type DispenseErrorCode,
+  type SessionErrorCode,
   type ApiError,
 } from "./types.js";
+
+/** Map HTTP status to a typed session error code. */
+function sessionErrorCode(status: number): SessionErrorCode {
+  if (status === 400) return "VALIDATION_ERROR";
+  if (status === 404) return "NOT_FOUND";
+  if (status === 409) return "CONFLICT";
+  return "SERVER_ERROR";
+}
 
 /**
  * HTTP client for distribution session management.
@@ -48,8 +58,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to create session: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to create session: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
 
@@ -76,8 +88,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to list sessions: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to list sessions: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
 
@@ -96,8 +110,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to get session: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to get session: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
 
@@ -127,8 +143,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to update session: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to update session: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
 
@@ -150,8 +168,10 @@ export class Distributions {
 
     if (!response.ok) {
       const error = (await response.json()) as ApiError;
-      throw new Error(
-        error.error || `Failed to delete session: ${response.statusText}`
+      throw new SessionError(
+        error.error || `Failed to delete session: ${response.statusText}`,
+        sessionErrorCode(response.status),
+        response.status,
       );
     }
   }
@@ -167,7 +187,8 @@ export class Distributions {
    * @throws {DispenseError} with typed code for programmatic handling:
    *   - `SESSION_NOT_FOUND` (404) — slug doesn't exist
    *   - `POOL_EMPTY` (404) — no keys left in inviter's pool
-   *   - `SESSION_EXPIRED` (410) — session expired or quota exhausted
+   *   - `SESSION_EXPIRED` (410) — session has expired
+   *   - `QUOTA_EXHAUSTED` (410) — session quota exhausted
    *   - `SESSION_PAUSED` (423) — session is paused
    *   - `RATE_LIMITED` (429) — too many requests
    */
@@ -196,7 +217,7 @@ export class Distributions {
           code = message.includes("keys available") ? "POOL_EMPTY" : "SESSION_NOT_FOUND";
           break;
         case 410:
-          code = "SESSION_EXPIRED";
+          code = message.includes("quota") ? "QUOTA_EXHAUSTED" : "SESSION_EXPIRED";
           break;
         case 423:
           code = "SESSION_PAUSED";

--- a/packages/referrals/src/index.ts
+++ b/packages/referrals/src/index.ts
@@ -2,6 +2,7 @@ export { Referrals } from "./referrals.js";
 export { Distributions } from "./distributions.js";
 export {
   DispenseError,
+  SessionError,
   type ReferralStatus,
   type ReferralInfo,
   type Referral,
@@ -13,4 +14,5 @@ export {
   type UpdateSessionParams,
   type DispenseResult,
   type DispenseErrorCode,
+  type SessionErrorCode,
 } from "./types.js";

--- a/packages/referrals/src/referrals.ts
+++ b/packages/referrals/src/referrals.ts
@@ -50,7 +50,7 @@ export class Referrals {
    * @throws Error if validation fails or key already exists
    */
   async store(privateKey: string, inviter: string): Promise<void> {
-    const response = await fetch(`${this.getBaseUrl()}/referral/store`, {
+    const response = await fetch(`${this.getBaseUrl()}/store`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ privateKey, inviter }),
@@ -74,7 +74,7 @@ export class Referrals {
    */
   async retrieve(privateKey: string): Promise<ReferralInfo> {
     const response = await fetch(
-      `${this.getBaseUrl()}/referral/retrieve?key=${encodeURIComponent(privateKey)}`
+      `${this.getBaseUrl()}/retrieve?key=${encodeURIComponent(privateKey)}`
     );
 
     if (!response.ok) {
@@ -99,7 +99,7 @@ export class Referrals {
     }
 
     const headers = await this.getAuthHeaders();
-    const response = await fetch(`${this.getBaseUrl()}/referral/my-referrals`, {
+    const response = await fetch(`${this.getBaseUrl()}/my-referrals`, {
       headers,
     });
 

--- a/packages/referrals/src/types.ts
+++ b/packages/referrals/src/types.ts
@@ -130,7 +130,8 @@ export interface DispenseResult {
 export type DispenseErrorCode =
   | "SESSION_NOT_FOUND"   // 404 - slug doesn't exist
   | "POOL_EMPTY"          // 404 - no keys left in inviter's pool
-  | "SESSION_EXPIRED"     // 410 - session expired or quota exhausted
+  | "SESSION_EXPIRED"     // 410 - session has expired
+  | "QUOTA_EXHAUSTED"     // 410 - session quota exhausted
   | "SESSION_PAUSED"      // 423 - session is paused
   | "RATE_LIMITED"        // 429 - too many requests
   | "UNKNOWN";            // other errors
@@ -146,5 +147,32 @@ export class DispenseError extends Error {
   ) {
     super(message);
     this.name = "DispenseError";
+  }
+}
+
+// ── Session CRUD Errors ─────────────────────────────────────────────
+
+/**
+ * Error codes for distribution session CRUD operations.
+ * Allows callers to programmatically distinguish failure modes.
+ */
+export type SessionErrorCode =
+  | "VALIDATION_ERROR"    // 400
+  | "NOT_FOUND"           // 404
+  | "CONFLICT"            // 409
+  | "SERVER_ERROR";       // 5xx
+
+/**
+ * Typed error thrown by session CRUD methods with HTTP status and code
+ * for programmatic handling.
+ */
+export class SessionError extends Error {
+  constructor(
+    message: string,
+    public readonly code: SessionErrorCode,
+    public readonly httpStatus: number,
+  ) {
+    super(message);
+    this.name = "SessionError";
   }
 }


### PR DESCRIPTION
## Summary

**Bug fix:**
- `Referrals` class had wrong URL paths — called `/referral/store` instead of `/store` (the backend mounts referral routes at the root prefix, not under `/referral/`). Same for `/retrieve` and `/my-referrals`. All 3 methods would 404 against both staging and DO prod.

**Improvements:**
- Add `QUOTA_EXHAUSTED` to `DispenseErrorCode` — distinguishes 410 "session expired" from "quota exhausted" by inspecting error message content
- Add `SessionError` class with `SessionErrorCode` for typed CRUD errors — callers can now programmatically distinguish 400 (validation) from 404 (not found) from 409 (conflict) from 5xx (server error)
- Export `SessionError` and `SessionErrorCode` from package index

## Test plan
- [x] TypeScript compiles with zero errors
- [ ] Manual test against staging: `store()`, `retrieve()`, `listMine()` now hit correct endpoints