### PR TITLE
fix(rpc): re-issue circles_subscribe after WebSocket reconnect

### DIFF
--- a/packages/rpc/src/client.ts
+++ b/packages/rpc/src/client.ts
@@ -19,6 +19,12 @@ export class RpcClient {
     [subscriptionId: string]: ((event: { event: string, values: Record<string, any> }[]) => void)[]
   } = {};
 
+  // Track parameters of active subscriptions so we can re-issue circles_subscribe
+  // after a reconnect. The server forgets prior subscriptionIds when the WS
+  // closes, so without this the server stops pushing events even though the
+  // client's local listeners are still attached.
+  private activeSubscriptions: { id: string, address?: Address }[] = [];
+
   // Backoff-related fields for reconnection
   private reconnectAttempt = 0;
   private readonly initialBackoff = 2000; // 2 seconds
@@ -188,9 +194,44 @@ export class RpcClient {
     try {
       await this.connect();
       console.log('Reconnection successful');
+      await this.resubscribeActive();
     } catch (err) {
       console.error('Reconnection attempt failed:', err);
       this.scheduleReconnect();
+    }
+  }
+
+  /**
+   * Re-issues circles_subscribe for every tracked active subscription so the
+   * server resumes pushing events after a reconnect. Server-assigned
+   * subscriptionIds change on each subscribe, so we move the existing
+   * listeners from the old id to the new one.
+   * @private
+   */
+  private async resubscribeActive(): Promise<void> {
+    if (this.activeSubscriptions.length === 0) return;
+
+    const previous = [...this.activeSubscriptions];
+    this.activeSubscriptions = [];
+
+    for (const entry of previous) {
+      try {
+        const params = entry.address ? { address: entry.address } : {};
+        const response = await this.sendMessage('circles_subscribe', params);
+        const newId = response.result;
+
+        const existingListeners = this.subscriptionListeners[entry.id];
+        if (existingListeners) {
+          this.subscriptionListeners[newId] = existingListeners;
+          delete this.subscriptionListeners[entry.id];
+        }
+
+        this.activeSubscriptions.push({ id: newId, address: entry.address });
+      } catch (err) {
+        console.error('Failed to re-issue circles_subscribe after reconnect:', err);
+        // Keep the entry so a subsequent reconnect can retry it.
+        this.activeSubscriptions.push(entry);
+      }
     }
   }
 
@@ -242,6 +283,8 @@ export class RpcClient {
     this.subscriptionListeners[subscriptionId].push((events) => {
       parseRpcSubscriptionMessage(events).forEach(event => observable.emit(event));
     });
+
+    this.activeSubscriptions.push({ id: subscriptionId, address: normalizedAddress });
 
     return observable.property;
   }


### PR DESCRIPTION
## Summary

When the WebSocket closes and `RpcClient` reconnects, the server forgets every prior `subscriptionId`. The client's local `subscriptionListeners` map is still wired up, but no events ever arrive again — consumers silently lose live updates for the rest of the page session.

## Fix

- Track `{ id, address }` for every active subscription in `activeSubscriptions`.
- After a successful `reconnect()`, walk that list and re-issue `circles_subscribe` for each entry.
- Rewire the existing listeners from the old (now-dead) `subscriptionId` to the new one returned by the server, so consumers don't have to re-call `subscribe()`.
- On a per-entry failure (e.g. transient send-message failure inside re-subscribe), keep the entry so the next reconnect cycle can retry it.

No public API changes; the fix is internal to `RpcClient.reconnect()` and `RpcClient.subscribe()`.

## Test plan

- `bun run build` clean across all workspaces
- Manual: existing `subscribe()` callers continue to work unchanged (no API changes)