### PR TITLE
fix(permissionless-groups): router approval, partial-drop pruning, MAX_FLOW guard

### DIFF
--- a/packages/permissionless-groups/src/PermissionlessGroup.ts
+++ b/packages/permissionless-groups/src/PermissionlessGroup.ts
@@ -11,7 +11,10 @@ import {
   replaceWrappedTokensWithAvatars,
 } from '@aboutcircles/sdk-pathfinder';
 import { PathfinderMethods, RpcClient } from '@aboutcircles/sdk-rpc';
-import { encodeAbiParameters } from '@aboutcircles/sdk-utils/abi';
+import {
+  encodeAbiParameters,
+  encodeFunctionData,
+} from '@aboutcircles/sdk-utils/abi';
 import {
   PERMISSIONLESS_GROUPS_MIGRATION,
   SCORE_GROUPS_STAGING_RPC_URL,
@@ -339,8 +342,11 @@ export class PermissionlessGroup {
       }
     );
 
+    const routerApprovalTx = await this._routerApprovalTxIfNeeded(params.avatar);
+    const allTxs = routerApprovalTx ? [routerApprovalTx, ...txs] : txs;
+
     return {
-      txs: txs as TransactionRequest[],
+      txs: allTxs as TransactionRequest[],
       amount: prep.scaledPath.maxFlow,
       requestedAmount: prep.rawPath.maxFlow,
       probedMaxFlow: prep.probedMaxFlow,
@@ -370,9 +376,24 @@ export class PermissionlessGroup {
     if (!params.avatar) {
       throw PermissionlessGroupError.invalidInput('migrationRaw() requires `avatar`');
     }
-    if (params.amount !== undefined && params.amount <= 0n) {
+    // The pathfinder's `MAX_FLOW` sentinel over-commits intermediate balances
+    // (sums per-edge flows without checking that intermediates actually hold
+    // the routed token), so the resulting plan typically reverts on-chain with
+    // `ERC1155InsufficientBalance`. `migration()` works around this with a
+    // two-stage probe + 10 bp buffer; `migrationRaw()` is the un-buffered
+    // pathfinder primitive and shouldn't paper over the footgun. Require an
+    // explicit amount.
+    if (params.amount === undefined) {
       throw PermissionlessGroupError.invalidInput(
-        'migrationRaw() amount must be > 0 when supplied (omit it to use MAX_FLOW)',
+        'migrationRaw() requires an explicit `amount` — the pathfinder ' +
+          "MAX_FLOW sentinel over-commits intermediate balances and the " +
+          'resulting plan usually reverts on-chain. Use migration() for a ' +
+          'safe max-flow path, or pass an explicit amount here.'
+      );
+    }
+    if (params.amount <= 0n) {
+      throw PermissionlessGroupError.invalidInput(
+        'migrationRaw() amount must be > 0',
         { amount: params.amount.toString() }
       );
     }
@@ -384,7 +405,7 @@ export class PermissionlessGroup {
     const path = await pathfinder.findPath({
       from: params.avatar,
       to: PERMISSIONLESS_GROUPS_MIGRATION.sinkWrapperAddress,
-      targetFlow: params.amount ?? MAX_FLOW,
+      targetFlow: params.amount,
       excludeFromTokens: [scoreGroup],
       toTokens: [scoreGroup],
       ...(params.fromTokens?.length ? { fromTokens: params.fromTokens } : {}),
@@ -393,7 +414,7 @@ export class PermissionlessGroup {
     if (!path.transfers || path.transfers.length === 0) {
       throw PermissionlessGroupError.invalidInput(
         'pathfinder returned no transfers for the requested migration amount',
-        { amount: params.amount?.toString() ?? 'max' }
+        { amount: params.amount.toString() }
       );
     }
 
@@ -409,7 +430,11 @@ export class PermissionlessGroup {
         useWrappedBalances: true,
       }
     );
-    return { txs: txs as TransactionRequest[], amount: path.maxFlow };
+
+    const routerApprovalTx = await this._routerApprovalTxIfNeeded(params.avatar);
+    const allTxs = routerApprovalTx ? [routerApprovalTx, ...txs] : txs;
+
+    return { txs: allTxs as TransactionRequest[], amount: path.maxFlow };
   }
 
   /**
@@ -632,6 +657,34 @@ export class PermissionlessGroup {
     };
   }
 
+  /**
+   * If the score router hasn't authorized `avatar` as an ERC1155 operator on
+   * the Hub yet, build the `setApprovalForCRC([avatar])` tx that grants the
+   * authorization. Returns `null` when the approval is already in place (or
+   * when the on-chain probe fails — we bias toward including the approval tx
+   * since it's cheap, idempotent, and a missing approval reverts the whole
+   * migration with `ERC1155MissingApprovalForAll`).
+   *
+   * The approval is permissionless on the router side, so this tx can be the
+   * first entry of the migration multisend without any prior on-chain state.
+   */
+  private async _routerApprovalTxIfNeeded(
+    avatar: Address
+  ): Promise<TransactionRequest | null> {
+    const router = PERMISSIONLESS_GROUPS_MIGRATION.scoreRouterAddress;
+    try {
+      const approved = await this.hub.isApprovedForAll(router, avatar);
+      if (approved) return null;
+    } catch (err) {
+      console.warn(
+        '[PermissionlessGroup] isApprovedForAll probe failed — ' +
+          'prepending setApprovalForCRC defensively',
+        err
+      );
+    }
+    return buildRouterApprovalTx(router, avatar);
+  }
+
   private async buildMintBatch(
     params: MintParams,
     proof: ProofResponse
@@ -719,6 +772,44 @@ export function encodePolicyData(score: bigint, proof: Hex): Hex {
 }
 
 /**
+ * Minimal ABI for the score router's permissionless approval entrypoint.
+ * `setApprovalForCRC(address[])` makes the router call
+ * `HUB.setApprovalForAll(crc, true)` for each address in the list — granting
+ * those addresses ERC1155 operator rights to spend CRCs held *by the router*.
+ * Without this, the Hub rejects the Router→ScoreGroup hop in operateFlowMatrix
+ * with `ERC1155MissingApprovalForAll(operator=avatar, owner=router)`.
+ */
+const SCORE_ROUTER_SET_APPROVAL_ABI = [
+  {
+    type: 'function',
+    name: 'setApprovalForCRC',
+    inputs: [{ name: 'crcArray', type: 'address[]' }],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+] as const;
+
+/**
+ * Build the router's `setApprovalForCRC([avatar])` call. The Router runs this
+ * permissionlessly — any caller can authorize any address — so this tx can be
+ * the first sub-tx in the migration multisend.
+ */
+export function buildRouterApprovalTx(
+  router: Address,
+  avatar: Address
+): TransactionRequest {
+  return {
+    to: router,
+    value: 0n,
+    data: encodeFunctionData({
+      abi: SCORE_ROUTER_SET_APPROVAL_ABI,
+      functionName: 'setApprovalForCRC',
+      args: [[avatar]],
+    }),
+  };
+}
+
+/**
  * Loose URL match — ignores trailing slashes and case. Good enough for
  * detecting "did the caller hand us the staging RPC under a slightly
  * different spelling".
@@ -771,7 +862,7 @@ function bucketPerCollateralAtRouter(
  * by their underlying avatars — we use it to identify which edges deposit
  * the *group* token id at the sink.
  */
-function pruneSinkBypassBranches(
+export function pruneSinkBypassBranches(
   path: PathfindingResult,
   resolvedPath: PathfindingResult,
   sink: Address,
@@ -780,8 +871,13 @@ function pruneSinkBypassBranches(
   const sinkLc = sink.toLowerCase();
   const groupLc = scoreGroup.toLowerCase();
 
-  // Mark indices that are bypass-edges to start.
-  const drop = new Set<number>();
+  // Per-edge drop bookkeeping. `dropAmount.get(i)` is how much to subtract
+  // from edge i's value when emitting the cleaned path. Bypass seed edges
+  // get a full drop (set to the edge's full value). Predecessor edges may
+  // get a partial drop when only part of their value funded the bypass —
+  // splitting an edge in two preserves the per-vertex netting invariant
+  // _verifyFlowMatrix relies on without losing the legitimate fraction.
+  const dropAmount = new Map<number, bigint>();
   let prunedAmount = 0n;
 
   // Find bypass *sink* edges in the resolved path: to == sink AND tokenOwner
@@ -794,9 +890,10 @@ function pruneSinkBypassBranches(
       t.tokenOwner.toLowerCase() === groupLc &&
       t.from.toLowerCase() !== groupLc
     ) {
-      drop.add(i);
-      prunedAmount += BigInt(t.value);
-      seedVertices.push({ vertex: t.from.toLowerCase(), remaining: BigInt(t.value) });
+      const value = BigInt(t.value);
+      dropAmount.set(i, value);
+      prunedAmount += value;
+      seedVertices.push({ vertex: t.from.toLowerCase(), remaining: value });
     }
   }
 
@@ -807,48 +904,60 @@ function pruneSinkBypassBranches(
   // Walk backwards: each bypass vertex V0 had its outflow X dropped, so V0's
   // net is now `+X` (received more than sent). To restore `V0` net = 0, drop
   // X-worth of V0's inflow edges. Each predecessor edge `W → V0` we drop
-  // moves W from net=0 to net=+X (W's outflow dropped). Continue until W is
-  // the original source (Safe) — at which point reduced outflow is fine,
-  // since the maxFlow is meant to drop by the bypassed amount.
+  // moves W from net=0 to net=+(dropped). Continue until W is the original
+  // source (Safe) — reduced outflow is fine there since the maxFlow drops by
+  // the bypassed amount anyway.
   //
-  // _verifyFlowMatrix nets per-vertex (not per-tokenOwner), so dropping an
-  // inflow edge of a different tokenOwner than the outflow that triggered it
-  // is still consistent.
+  // When a predecessor edge funds *more* than the bypass needs, we partial-
+  // drop just the bypass share and leave the rest intact (the edge had a
+  // legitimate downstream use we mustn't break). Each edge has exactly one
+  // `to`, so the same edge is never visited as inflow by two different
+  // vertices — no need to track residual capacity across walks.
+  //
+  // _verifyFlowMatrix nets per-vertex (not per-tokenOwner), so dropping or
+  // partial-dropping an inflow edge of a different tokenOwner than the
+  // outflow that triggered it is still consistent.
   const queue: Array<{ vertex: string; remaining: bigint }> = [...seedVertices];
   while (queue.length) {
     const { vertex, remaining } = queue.shift()!;
     let stillNeeded = remaining;
     for (let i = 0; i < resolvedPath.transfers.length; i++) {
       if (stillNeeded === 0n) break;
-      if (drop.has(i)) continue;
+      if (dropAmount.has(i)) continue;
       const t = resolvedPath.transfers[i];
       if (t.to.toLowerCase() !== vertex) continue;
       const value = BigInt(t.value);
-      // The pathfinder's bypass branches are single-edge funding chains in
-      // practice (verified against the staging path). Whole-edge drops keep
-      // values bigint-exact — splitting edges would require recomputing
-      // coordinates downstream. If we ever hit `value > stillNeeded`, the
-      // assumption no longer holds and we bail out loudly.
       if (value > stillNeeded) {
-        throw new Error(
-          `pruneSinkBypassBranches: predecessor edge ${i} (value=${value}) ` +
-            `exceeds bypassed outflow ${stillNeeded} for vertex ${vertex}. ` +
-            `Path topology not supported — re-run pathfinder with a different ` +
-            `excludeFromTokens / fromTokens combination.`
-        );
+        // Partial drop: take exactly stillNeeded out of this edge, leave the
+        // remainder funding whatever downstream the rest was for. Push the
+        // partial amount onto W's queue so its inflow also shrinks by the
+        // same fraction — keeping W's net zero.
+        dropAmount.set(i, stillNeeded);
+        queue.push({ vertex: t.from.toLowerCase(), remaining: stillNeeded });
+        stillNeeded = 0n;
+      } else {
+        // Full drop: this edge funded only bypass-bound flow (or less than
+        // bypass). Drop the whole edge and continue accumulating.
+        dropAmount.set(i, value);
+        stillNeeded -= value;
+        queue.push({ vertex: t.from.toLowerCase(), remaining: value });
       }
-      drop.add(i);
-      stillNeeded -= value;
-      queue.push({ vertex: t.from.toLowerCase(), remaining: value });
     }
   }
 
-  // Apply the drop set to the *original* (wrapper-keyed) path so wrapped
-  // edge semantics survive.
-  const kept = path.transfers.filter((_, i) => !drop.has(i));
+  // Apply the drop bookkeeping to the *original* (wrapper-keyed) path so
+  // wrapped edge semantics survive. For each edge, subtract the drop amount;
+  // omit entirely when fully dropped, keep with reduced value otherwise.
+  const kept: PathfindingResult['transfers'] = [];
   let maxFlow = 0n;
-  for (const t of kept) {
-    if (t.to.toLowerCase() === sinkLc) maxFlow += BigInt(t.value);
+  for (let i = 0; i < path.transfers.length; i++) {
+    const t = path.transfers[i];
+    const drop = dropAmount.get(i) ?? 0n;
+    const remaining = BigInt(t.value) - drop;
+    if (remaining <= 0n) continue;
+    const kept_t = { ...t, value: remaining };
+    kept.push(kept_t);
+    if (t.to.toLowerCase() === sinkLc) maxFlow += remaining;
   }
   return { path: { maxFlow, transfers: kept }, prunedAmount };
 }

--- a/packages/permissionless-groups/src/tests/migrationRawGuard.test.ts
+++ b/packages/permissionless-groups/src/tests/migrationRawGuard.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'bun:test';
+import { PermissionlessGroup } from '../PermissionlessGroup.js';
+
+// Minimal config — only used to construct the instance; the guarded code path
+// runs before any network call, so we don't need a working RPC.
+const RPC = 'https://rpc.staging.aboutcircles.com/';
+const CONFIG = {
+  groupAddress: '0x0000000000000000000000000000000000000aaa' as `0x${string}`,
+  hubAddress: '0x0000000000000000000000000000000000000bbb' as `0x${string}`,
+  liftERC20Address: '0x0000000000000000000000000000000000000ccc' as `0x${string}`,
+  backendBaseUrl: 'https://score-groups-backend.staging.example.com',
+  rpcUrl: RPC,
+  circlesConfig: {
+    circlesRpcUrl: RPC,
+    v2HubAddress: '0x0000000000000000000000000000000000000bbb' as `0x${string}`,
+    liftERC20Address: '0x0000000000000000000000000000000000000ccc' as `0x${string}`,
+  } as any,
+};
+
+const AVATAR = '0x0000000000000000000000000000000000000ddd' as `0x${string}`;
+
+async function expectThrows(p: Promise<unknown>, pattern: RegExp): Promise<void> {
+  let thrown: unknown = null;
+  try {
+    await p;
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown).not.toBeNull();
+  const msg = thrown instanceof Error ? thrown.message : String(thrown);
+  expect(msg).toMatch(pattern);
+}
+
+describe('migrationRaw — MAX_FLOW guard', () => {
+  test('throws when amount is undefined', async () => {
+    const group = new PermissionlessGroup(CONFIG);
+    await expectThrows(group.migrationRaw({ avatar: AVATAR }), /explicit `amount`/);
+  });
+
+  test('throws when amount is zero', async () => {
+    const group = new PermissionlessGroup(CONFIG);
+    await expectThrows(
+      group.migrationRaw({ avatar: AVATAR, amount: 0n }),
+      /must be > 0/
+    );
+  });
+
+  test('throws when avatar is missing', async () => {
+    const group = new PermissionlessGroup(CONFIG);
+    await expectThrows(
+      // @ts-expect-error - avatar intentionally missing
+      group.migrationRaw({ amount: 100n }),
+      /requires `avatar`/
+    );
+  });
+});

--- a/packages/permissionless-groups/src/tests/pruneSinkBypassBranches.test.ts
+++ b/packages/permissionless-groups/src/tests/pruneSinkBypassBranches.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect } from 'bun:test';
+import { pruneSinkBypassBranches } from '../PermissionlessGroup.js';
+import type { Address, PathfindingResult, TransferStep } from '@aboutcircles/sdk-types';
+
+const SINK = '0x0000000000000000000000000000000000000001' as Address;
+const GROUP = '0x0000000000000000000000000000000000000002' as Address;
+const SAFE = '0x0000000000000000000000000000000000000003' as Address;
+const ROUTER = '0x0000000000000000000000000000000000000004' as Address;
+const HOLDER = '0x0000000000000000000000000000000000000005' as Address;
+const OTHER = '0x0000000000000000000000000000000000000006' as Address;
+
+function step(
+  from: Address,
+  to: Address,
+  tokenOwner: Address,
+  value: bigint
+): TransferStep {
+  return { from, to, tokenOwner, value };
+}
+
+function pathOf(transfers: TransferStep[]): PathfindingResult {
+  // maxFlow = sum of edges landing at SINK
+  let maxFlow = 0n;
+  for (const t of transfers) if (t.to.toLowerCase() === SINK.toLowerCase()) maxFlow += t.value;
+  return { maxFlow, transfers };
+}
+
+describe('pruneSinkBypassBranches', () => {
+  test('no-op when there are no bypass edges', () => {
+    const path = pathOf([
+      step(SAFE, ROUTER, SAFE, 100n),
+      step(ROUTER, GROUP, SAFE, 100n),
+      step(GROUP, SINK, GROUP, 100n),
+    ]);
+    const out = pruneSinkBypassBranches(path, path, SINK, GROUP);
+    expect(out.prunedAmount).toBe(0n);
+    expect(out.path.transfers).toEqual(path.transfers);
+    expect(out.path.maxFlow).toBe(100n);
+  });
+
+  test('full drop: predecessor edge exactly matches bypass amount', () => {
+    // SAFE -> HOLDER (group token, 50) -> SINK (bypass)
+    // Plus a legitimate parallel flow.
+    const path = pathOf([
+      step(SAFE, HOLDER, GROUP, 50n), // funds the bypass
+      step(HOLDER, SINK, GROUP, 50n), // BYPASS (HOLDER is not GROUP)
+      step(SAFE, ROUTER, SAFE, 100n),
+      step(ROUTER, GROUP, SAFE, 100n),
+      step(GROUP, SINK, GROUP, 100n),
+    ]);
+    const out = pruneSinkBypassBranches(path, path, SINK, GROUP);
+    expect(out.prunedAmount).toBe(50n);
+    // The bypass + its sole funder are gone; legitimate flow preserved.
+    expect(out.path.transfers).toEqual([
+      step(SAFE, ROUTER, SAFE, 100n),
+      step(ROUTER, GROUP, SAFE, 100n),
+      step(GROUP, SINK, GROUP, 100n),
+    ]);
+    expect(out.path.maxFlow).toBe(100n);
+  });
+
+  test('partial drop: predecessor edge funds bypass + something else', () => {
+    // SAFE -> HOLDER (group token, 70). HOLDER sends 50 to SINK (bypass)
+    // and 20 to OTHER (legit downstream). The funder must NOT be fully
+    // dropped — only the 50-bypass share — or the legit OTHER hop loses
+    // its inflow and HOLDER's net breaks.
+    const path = pathOf([
+      step(SAFE, HOLDER, GROUP, 70n), // funds bypass(50) + legit(20)
+      step(HOLDER, SINK, GROUP, 50n), // BYPASS
+      step(HOLDER, OTHER, GROUP, 20n), // LEGIT — must survive (no bypass marker since OTHER != SINK)
+    ]);
+    const out = pruneSinkBypassBranches(path, path, SINK, GROUP);
+    expect(out.prunedAmount).toBe(50n);
+    // Funder edge value reduced from 70 -> 20; bypass dropped; legit preserved.
+    expect(out.path.transfers).toEqual([
+      step(SAFE, HOLDER, GROUP, 20n),
+      step(HOLDER, OTHER, GROUP, 20n),
+    ]);
+    // HOLDER net: +20 in, -20 out → zero. SAFE net: -20 (reduced from -70).
+    expect(out.path.maxFlow).toBe(0n);
+  });
+
+  test('multi-hop full drops chain back to source', () => {
+    // SAFE -> A -> B -> SINK (all group token, 30). All edges drop, no
+    // leftover, no thrown errors.
+    const A = '0x000000000000000000000000000000000000000a' as Address;
+    const B = '0x000000000000000000000000000000000000000b' as Address;
+    const path = pathOf([
+      step(SAFE, A, GROUP, 30n),
+      step(A, B, GROUP, 30n),
+      step(B, SINK, GROUP, 30n),
+    ]);
+    const out = pruneSinkBypassBranches(path, path, SINK, GROUP);
+    expect(out.prunedAmount).toBe(30n);
+    expect(out.path.transfers).toEqual([]);
+    expect(out.path.maxFlow).toBe(0n);
+  });
+
+  test('bypass with token-owner != GROUP is not pruned (sanity)', () => {
+    // Vertex sends to SINK but tokenOwner is SAFE's personal CRC, not the
+    // group token. This isn't a "bypass" by the function's definition.
+    const path = pathOf([
+      step(SAFE, HOLDER, SAFE, 50n),
+      step(HOLDER, SINK, SAFE, 50n),
+    ]);
+    const out = pruneSinkBypassBranches(path, path, SINK, GROUP);
+    expect(out.prunedAmount).toBe(0n);
+    expect(out.path.transfers).toEqual(path.transfers);
+  });
+
+  test('does NOT throw when predecessor edge exceeds bypass (partial-drop case)', () => {
+    // This is the case the old implementation threw on. Verify the new
+    // implementation handles it via partial drop instead of bailing out.
+    const path = pathOf([
+      step(SAFE, HOLDER, GROUP, 1000n), // way more than the bypass needs
+      step(HOLDER, SINK, GROUP, 5n), // tiny bypass
+      step(HOLDER, OTHER, GROUP, 995n), // legitimate larger outflow
+    ]);
+    expect(() => pruneSinkBypassBranches(path, path, SINK, GROUP)).not.toThrow();
+    const out = pruneSinkBypassBranches(path, path, SINK, GROUP);
+    expect(out.prunedAmount).toBe(5n);
+    // Funder edge: 1000 - 5 = 995. Legit outflow preserved.
+    expect(out.path.transfers).toEqual([
+      step(SAFE, HOLDER, GROUP, 995n),
+      step(HOLDER, OTHER, GROUP, 995n),
+    ]);
+    expect(out.path.maxFlow).toBe(0n);
+  });
+});


### PR DESCRIPTION
Three independent fixes to migration failure modes surfaced by simulating `migrationRaw()` / `migration()` outputs via `eth_call`.

## 1. Router approval gap (`ERC1155MissingApprovalForAll`)

The flow matrix routes the migration through the ScoreGroup's path-mint router. Inside `operateFlowMatrix`, the Hub's ERC1155 rejects the `Router → ScoreGroup` hop unless `isApprovedForAll(router, avatar) == true`. Without that approval the entire migration reverts.

The router exposes `setApprovalForCRC(address[])` permissionlessly for exactly this purpose. Both `migration()` and `migrationRaw()` now probe `Hub.isApprovedForAll(router, avatar)`; when `false`, they prepend the router's `setApprovalForCRC([avatar])` sub-tx. On probe failure the approval tx is included defensively (cheap and idempotent — safer than gambling on a flaky RPC response).

**Correlation that motivated this** (verified on-chain): of four test Safes, the two that completed migration end-to-end had `isApprovedForAll(router, safe) == true`; the two that reverted had it `false`.

## 2. `pruneSinkBypassBranches`: partial drops

The previous implementation `throw`-ed when a predecessor edge funded *more* than the bypass amount. That topology occurs whenever a vertex aggregates bypass-bound and legitimate outflow under one inflow edge — common enough that this was a regular `SDK_THREW` source.

The walker now partial-drops exactly the bypass share and leaves the rest intact. Per-vertex netting stays consistent because the partial drop is also propagated as a partial reduction to the predecessor's inflow. Function is now exported for unit-test access.

## 3. `migrationRaw()`: refuse `amount: undefined`

The pathfinder's `MAX_FLOW` sentinel over-commits intermediate balances (sums per-edge flows without checking that intermediates actually hold the routed token), so the resulting plan typically reverts with `ERC1155InsufficientBalance`. `migration()` works around this with a two-stage probe + 10 bp buffer; `migrationRaw()` is the un-buffered primitive and shouldn't paper over the footgun. Now throws a clear error directing callers to `migration()` for safe max-flow.

## Out of scope (needs separate work)

The migration simulation sweep also surfaced an `ERC1155InsufficientBalance` failure mode driven by the pathfinder collapsing wrapper + native ERC1155 balances under one `(safe, avatar)` total in the path output. The SDK currently can't reliably reconcile per-wrapper unwraps from a single avatar-keyed source edge. Fixing this needs either:
- a path-schema extension on the pathfinder side communicating per-wrapper resolution, or
- a defensive SDK-side reconciliation pass (per-edge native-balance check + targeted unwrap insertion).

Deliberately not addressed here — both options need design alignment before code lands.

## Test plan

- [x] `bun test packages/permissionless-groups/src/tests/` — 9 pass (6 partial-drop scenarios incl. regression for the previously-thrown topology + 3 migrationRaw input guards)
- [x] `bun run --filter '@aboutcircles/sdk-permissionless-groups' build` — clean build
- [ ] Run sweep against staging using local SDK build to validate prepend behavior in live conditions (depends on test Safes having migratable balance — most were already migrated since the previous sweep)