### PR TITLE
feat(invitations): cross-leg token exclusions to prevent batch double-spends

### DIFF
--- a/packages/invitations/src/Invitations.ts
+++ b/packages/invitations/src/Invitations.ts
@@ -309,7 +309,11 @@ export class Invitations {
    * Note: The invitee MUST have a Safe wallet but MUST NOT be registered in Circles Hub yet.
    * If they are already registered, an error will be thrown.
    */
-  async generateInvite(inviter: Address, invitee: Address): Promise<TransactionRequest[]> {
+  async generateInvite(
+    inviter: Address,
+    invitee: Address,
+    options?: { excludeFromTokens?: Address[] }
+  ): Promise<TransactionRequest[]> {
 
     const inviterLower = inviter.toLowerCase() as Address;
     const inviteeLower = invitee.toLowerCase() as Address;
@@ -335,7 +339,11 @@ export class Invitations {
       console.log('[generateInvite] Using STANDARD PATH (proxy inviters available)');
       const realInviterAddress = realInviters[0].address;
 
-      const path = await this.findInvitePath(inviterLower, realInviterAddress);
+      const path = await this.findInvitePath(
+        inviterLower,
+        realInviterAddress,
+        options?.excludeFromTokens
+      );
 
       const transferBuilder = new TransferBuilder(this.config);
 
@@ -355,7 +363,11 @@ export class Invitations {
       // No proxy inviters. Try the farm fallback (pay 96 CRC for quota); if the
       // inviter can't afford it, fall back to a Gnosis Pay free invite.
       transactions.push(
-        ...(await this.buildFarmOrFreeInviteTransactions(inviterLower, transferData))
+        ...(await this.buildFarmOrFreeInviteTransactions(
+          inviterLower,
+          transferData,
+          options?.excludeFromTokens
+        ))
       );
     }
 
@@ -371,18 +383,20 @@ export class Invitations {
    *
    * @param inviter - Address of the inviter (lowercased)
    * @param transferData - Encoded invitation transfer data
+   * @param excludeFromTokens - Token owners other legs of the same batch already spend
    * @returns The funding/claim/transfer transactions
    */
   private async buildFarmOrFreeInviteTransactions(
     inviter: Address,
-    transferData: `0x${string}`
+    transferData: `0x${string}`,
+    excludeFromTokens?: Address[]
   ): Promise<TransactionRequest[]> {
     try {
       // Farm fallback: send 96 CRC to the farm destination to earn quota, then
       // claim + transfer the invite token.
       console.log('[invitations] Using FARM FALLBACK PATH (no proxy inviters available)');
       const transferBuilder = new TransferBuilder(this.config);
-      const farmPath = await this.findFarmInvitePath(inviter);
+      const farmPath = await this.findFarmInvitePath(inviter, excludeFromTokens);
 
       const quotaTransactions = await transferBuilder.buildFlowMatrixTx(
         inviter,
@@ -422,6 +436,8 @@ export class Invitations {
    *
    * @param inviter - Address of the inviter
    * @param proxyInviterAddress - Optional specific proxy inviter address to use for the path
+   * @param excludeFromTokens - Token owners other legs of the same batch already spend;
+   *   excluded here so two independently built legs cannot double-spend one balance
    * @returns PathfindingResult containing the transfer path
    *
    * @description
@@ -429,7 +445,11 @@ export class Invitations {
    * If proxyInviterAddress is provided, it will find a path using that specific token.
    * Otherwise, it will use the first available proxy inviter.
    */
-  async findInvitePath(inviter: Address, proxyInviterAddress?: Address) {
+  async findInvitePath(
+    inviter: Address,
+    proxyInviterAddress?: Address,
+    excludeFromTokens?: Address[]
+  ) {
 
     const inviterLower = inviter.toLowerCase() as Address;
 
@@ -457,6 +477,7 @@ export class Invitations {
       toTokens: [tokenToUse],
       useWrappedBalances: true,
       simulatedTrusts: [{ truster: this.config.invitationModuleAddress, trustee: inviterLower }],
+      ...(excludeFromTokens?.length ? { excludeFromTokens } : {}),
     });
 
 
@@ -490,7 +511,7 @@ export class Invitations {
    * This function finds a path from the inviter to the farm destination (0x9Eb51E6A39B3F17bB1883B80748b56170039ff1d)
    * using FARM_TO_TOKEN as the target token. Used when no standard proxy inviters are available.
    */
-  async findFarmInvitePath(inviter: Address) {
+  async findFarmInvitePath(inviter: Address, excludeFromTokens?: Address[]) {
 
     const inviterLower = inviter.toLowerCase() as Address;
 
@@ -500,7 +521,8 @@ export class Invitations {
       to: FARM_DESTINATION,
       targetFlow: INVITATION_FEE,
       toTokens: [FARM_TO_TOKEN],
-      useWrappedBalances: true
+      useWrappedBalances: true,
+      ...(excludeFromTokens?.length ? { excludeFromTokens } : {}),
     });
 
 
@@ -662,7 +684,8 @@ export class Invitations {
    * 7. Returns transactions and the generated private key
    */
   async generateReferral(
-    inviter: Address
+    inviter: Address,
+    options?: { excludeFromTokens?: Address[] }
   ): Promise<{ transactions: TransactionRequest[]; privateKey: `0x${string}` }> {
 
     const inviterLower = inviter.toLowerCase() as Address;
@@ -686,7 +709,11 @@ export class Invitations {
       const transferBuilder = new TransferBuilder(this.config);
 
       const realInviterAddress = realInviters[0].address;
-      const path = await this.findInvitePath(inviterLower, realInviterAddress);
+      const path = await this.findInvitePath(
+        inviterLower,
+        realInviterAddress,
+        options?.excludeFromTokens
+      );
 
       const transferTransactions = await transferBuilder.buildFlowMatrixTx(
         inviterLower,
@@ -704,7 +731,11 @@ export class Invitations {
       // No proxy inviters. Try the farm fallback (pay 96 CRC for quota); if the
       // inviter can't afford it, fall back to a Gnosis Pay free invite.
       transactions.push(
-        ...(await this.buildFarmOrFreeInviteTransactions(inviterLower, transferData))
+        ...(await this.buildFarmOrFreeInviteTransactions(
+          inviterLower,
+          transferData,
+          options?.excludeFromTokens
+        ))
       );
     }
 

--- a/packages/pathfinder/src/path.ts
+++ b/packages/pathfinder/src/path.ts
@@ -53,6 +53,32 @@ export function getWrappedTokensFromPath(
   return wrappedTokensInPath;
 }
 
+/**
+ * Collect the distinct token owners (avatars) that `avatar` spends in `path`.
+ * Wrapped-token entries are resolved to their underlying avatar, so the result
+ * can be passed to the pathfinder's `excludeFromTokens` (the server expands an
+ * avatar to its wrapped forms). Use this to keep a second, independently built
+ * leg of the same batch from drawing on balances this path already consumes.
+ */
+export function getSourcedTokenOwnersFromPath(
+  avatar: Address,
+  path: PathfindingResult,
+  tokenInfoMap: Map<string, TokenInfo>
+): Address[] {
+  const avatarLower = avatar.toLowerCase();
+  const owners = new Set<string>();
+
+  path.transfers.forEach((t) => {
+    if (t.from.toLowerCase() !== avatarLower) return;
+    const ownerLower = t.tokenOwner.toLowerCase();
+    const info = tokenInfoMap.get(ownerLower);
+    const isWrapper = info && info.tokenType.startsWith('CrcV2_ERC20WrapperDeployed');
+    owners.add(isWrapper ? info!.tokenOwner.toLowerCase() : ownerLower);
+  });
+
+  return Array.from(owners) as Address[];
+}
+
 export function getExpectedUnwrappedTokenTotals(
   wrappedTotals: Record<string, [bigint, string]>,
   tokenInfoMap: Map<string, TokenInfo>

--- a/packages/permissionless-groups/src/PermissionlessGroup.ts
+++ b/packages/permissionless-groups/src/PermissionlessGroup.ts
@@ -10,6 +10,10 @@ import {
   MerkleTreeRegistryContractMinimal,
 } from '@aboutcircles/sdk-core/minimal';
 import { TransferBuilder } from '@aboutcircles/sdk-transfers';
+import {
+  getTokenInfoMapFromPath,
+  getSourcedTokenOwnersFromPath,
+} from '@aboutcircles/sdk-pathfinder';
 import { PathfinderMethods, RpcClient } from '@aboutcircles/sdk-rpc';
 import { encodeAbiParameters } from '@aboutcircles/sdk-utils/abi';
 import { CirclesConverter } from '@aboutcircles/sdk-utils/circlesConverter';
@@ -408,7 +412,7 @@ export class PermissionlessGroup {
    * to the pathfinder's `maxTransfers`).
    *
    * When nothing can be migrated (the pathfinder finds no route), this returns
-   * an empty batch `{ txs: [], amount: 0n }` rather than throwing — migration
+   * an empty batch `{ txs: [], amount: 0n, sourcedTokens: [] }` rather than throwing — migration
    * being impossible is a normal state, so callers can simply check
    * `txs.length`/`amount`. Submission is the caller's job; the returned `txs`
    * are meant to be sent atomically through a Safe runner.
@@ -416,7 +420,7 @@ export class PermissionlessGroup {
   async migration(params: MigrationParams): Promise<MigrationResult> {
     const path = await this.migrationPath(params);
     if (!path.transfers || path.transfers.length === 0) {
-      return { txs: [], amount: 0n };
+      return { txs: [], amount: 0n, sourcedTokens: [] };
     }
 
     const scoreGroup = PERMISSIONLESS_GROUPS_MIGRATION.scoreGroupAddress;
@@ -432,7 +436,18 @@ export class PermissionlessGroup {
         useWrappedBalances: true,
       }
     );
-    return { txs: txs as TransactionRequest[], amount: path.maxFlow };
+
+    // Report which of the avatar's tokens this batch spends, so callers
+    // composing further pathfinder legs into the same Safe batch can exclude
+    // them and not plan a second spend of the same balance.
+    const tokenInfoMap = await getTokenInfoMapFromPath(
+      params.avatar,
+      this.config.circlesConfig.circlesRpcUrl,
+      path
+    );
+    const sourcedTokens = getSourcedTokenOwnersFromPath(params.avatar, path, tokenInfoMap);
+
+    return { txs: txs as TransactionRequest[], amount: path.maxFlow, sourcedTokens };
   }
 
   /**

--- a/packages/permissionless-groups/src/types.ts
+++ b/packages/permissionless-groups/src/types.ts
@@ -218,6 +218,13 @@ export interface MigrationResult {
   txs: TransactionRequest[];
   /** Atto-CRC the pathfinder routed into the SinkWrapper. */
   amount: bigint;
+  /**
+   * Token owners (avatars) the migration path spends from `avatar`, wrapped
+   * entries resolved to their underlying avatar. Pass these as
+   * `excludeFromTokens` to any further pathfinder leg built for the same
+   * batch, so the two legs cannot double-spend the same balance.
+   */
+  sourcedTokens: Address[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Composed Safe batches that contain multiple independently path-found legs (e.g. legacy-CRC migration + invitation transfer) can double-spend the same token balance: each leg's pathfinder call plans against the same live state, so both may source the same (wrapped) balance. On-chain, the first leg's `unwrap` consumes it and the second leg's `unwrap` of the same amount reverts `ERC20InsufficientBalance` during 4337 simulation. Rebuild-on-retry cannot fix this — rebuilding against unchanged chain state reproduces the same collision deterministically.

## Changes

- `PermissionlessGroup.migration()` now returns `sourcedTokens` — the token owners (avatars) the migration path spends from the avatar, wrapped entries resolved to their underlying avatar.
- New `getSourcedTokenOwnersFromPath()` helper in `@aboutcircles/sdk-pathfinder`.
- `Invitations.generateReferral()` / `generateInvite()` accept `options.excludeFromTokens`, forwarded to `findInvitePath()` / `findFarmInvitePath()` and into the pathfinder request.
- Callers pass avatar addresses only — the pathfinder server expands an excluded avatar to its wrapped forms.

Additive only; no behavior change for existing callers.

## Test plan

- [x] `bun run build` (tsc --build + all package builds) — green
- [x] Live verification against the production RPC: with exclusions applied, a previously colliding migration+referral composition produces disjoint unwrap sets, the invite leg still reaches the full 96 CRC, and the composed batch passes a chained `eth_simulateV1`; when exclusions make the target unreachable, the existing insufficient-balance error is thrown at build time instead of signing a doomed tx
- [ ] Version bump + npm release (maintainer flow) — consumer apps need a release to pass `excludeFromTokens`