### PR TITLE
fix(permissionless-groups): treat zero mint-max as empty batch, not an error

### DIFF
--- a/packages/permissionless-groups/src/PermissionlessGroup.ts
+++ b/packages/permissionless-groups/src/PermissionlessGroup.ts
@@ -659,6 +659,17 @@ export class PermissionlessGroup {
     const rawScore = BigInt(proof.scoreRaw);
     const policyData = encodePolicyData(rawScore, proof.proof);
     const amount = await this.resolveAmount(params, clampScore(rawScore));
+
+    // "Mint max" with no claimable issuance right now is a normal empty state,
+    // not an error: issuance accrues over time, so an avatar that just minted
+    // has ~0 and `(issuance × score) / 100` floors to 0. Return an empty batch
+    // so callers branch on `amount`/`txs.length` — mirroring `migration()` and
+    // the `scoreRaw === "0"` path in `mint()`. Building a 0-amount groupMint
+    // would only produce a batch that reverts on-chain.
+    if (amount === 0n) {
+      return { txs: [], proof, amount: 0n };
+    }
+
     const policy = await this.policy();
 
     const txs: TransactionRequest[] = [
@@ -715,6 +726,11 @@ export class PermissionlessGroup {
    * is read from `Hub.calculateIssuance(avatar)` *before* the snapshot/personalMint
    * pair runs — those operate in the same block, so the value the policy
    * captures with `snapshotIssuance()` matches what we read here.
+   *
+   * Returns `0n` when the avatar has no claimable issuance right now (it just
+   * minted, so nothing has accrued yet). That's a normal empty state, not an
+   * error — {@link buildMintBatch} turns a 0 resolve into an empty batch
+   * instead of throwing.
    */
   private async resolveAmount(
     params: MintParams,
@@ -723,18 +739,7 @@ export class PermissionlessGroup {
     if (params.amount !== undefined && params.amount > 0n) return params.amount;
 
     const [issuance] = await this.hub.calculateIssuance(params.avatar);
-    const maxMintable = (issuance * score) / MAX_SCORE;
-    if (maxMintable === 0n) {
-      throw PermissionlessGroupError.invalidInput(
-        "mint-max resolved to 0: avatar has no claimable issuance right now",
-        {
-          avatar: params.avatar,
-          snapshottedIssuance: issuance.toString(),
-          score: score.toString(),
-        },
-      );
-    }
-    return maxMintable;
+    return (issuance * score) / MAX_SCORE;
   }
 }
 

--- a/packages/permissionless-groups/src/tests/mint.test.ts
+++ b/packages/permissionless-groups/src/tests/mint.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect } from 'bun:test';
+import type { Address } from '@aboutcircles/sdk-types';
+import { PermissionlessGroup } from '../PermissionlessGroup.js';
+import type { ProofResponse } from '../types.js';
+
+const GROUP = '0xc19bc204eb1c1d5b3fe500e5e5dfabab625f286c' as Address;
+const HUB = '0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8' as Address;
+const LIFT = '0x5F99a795dD2743C36D63511f0D4bc667e6d3cDB5' as Address;
+const AVATAR = '0x4d825a98ee3e4801e39f2de6dd16184de2285ce4' as Address;
+
+/** Build a complete ProofResponse with an overridable `scoreRaw`. */
+function proofWith(scoreRaw: string): ProofResponse {
+  return {
+    groupAddress: GROUP,
+    userAddress: AVATAR,
+    value: '0x00',
+    scoreRaw,
+    proof: '0x',
+    root: '0x1234',
+    depth: 160,
+    publishStatus: 'published',
+    rootPublishedAt: '2026-06-18T00:00:00.000Z',
+    lastHeadChangedAt: '2026-06-18T00:00:00.000Z',
+    nextHeadEarliestAt: null,
+    publishCadenceSeconds: 300,
+    serverTime: '2026-06-18T00:00:01.000Z',
+    proofValidityModel: 'single-root',
+  };
+}
+
+/**
+ * Construct a PermissionlessGroup with the on-chain/backend seams stubbed.
+ * The constructor only stores addresses (no network), so we can override the
+ * public `client`/`hub` fields on the instance to drive `mint()` deterministically.
+ */
+function makeGroup(opts: { scoreRaw: string; issuance: bigint }): PermissionlessGroup {
+  const pg = new PermissionlessGroup({
+    groupAddress: GROUP,
+    hubAddress: HUB,
+    liftERC20Address: LIFT,
+    backendBaseUrl: 'http://backend.invalid',
+    rpcUrl: 'http://rpc.invalid',
+    circlesConfig: {} as never,
+  });
+
+  // Backend proof fetch.
+  (pg as { client: unknown }).client = {
+    getProof: async () => proofWith(opts.scoreRaw),
+  };
+
+  // Stub every on-chain call the mint paths reach. `calculateIssuance` returns
+  // a tuple whose first element is the issuance; the tx-builders just return
+  // recognizable TransactionRequests so we can assert batch shape.
+  (pg as { hub: unknown }).hub = {
+    calculateIssuance: async () => [opts.issuance],
+    isTrusted: async () => true, // skip the optional group.trust() prefix
+    personalMint: () => ({ to: HUB, data: '0xpersonalmint' }),
+    groupMint: () => ({ to: HUB, data: '0xgroupmint' }),
+    wrap: () => ({ to: HUB, data: '0xwrap' }),
+  };
+
+  // Pre-resolve the policy so `policy()` skips the mintPolicies() lookup.
+  // `policyPromise` is private, so cast through `unknown`.
+  (pg as unknown as { policyPromise: unknown }).policyPromise = Promise.resolve({
+    snapshotIssuance: () => ({ to: HUB, data: '0xsnapshot' }),
+  });
+
+  return pg;
+}
+
+describe('PermissionlessGroup.mint() — empty-state handling', () => {
+  test('mint-max with zero claimable issuance returns an empty batch, not an error', async () => {
+    // score > 0 (eligible) but no accrued issuance → (issuance × score) / 100 == 0.
+    const pg = makeGroup({ scoreRaw: '50', issuance: 0n });
+
+    const result = await pg.mint({ avatar: AVATAR }); // amount omitted = mint max
+
+    expect(result.amount).toBe(0n);
+    expect(result.txs).toHaveLength(0);
+    expect(result.proof.scoreRaw).toBe('50');
+  });
+
+  test('score 0 still returns the personalMint-only batch (unchanged path)', async () => {
+    const pg = makeGroup({ scoreRaw: '0', issuance: 100n });
+
+    const result = await pg.mint({ avatar: AVATAR });
+
+    expect(result.amount).toBe(0n);
+    expect(result.txs).toHaveLength(1);
+  });
+
+  test('tiny issuance that floors the mintable to 0 is treated as empty, not an error', async () => {
+    // issuance × score < 100 → integer division floors to 0. Must not throw.
+    const pg = makeGroup({ scoreRaw: '1', issuance: 50n });
+
+    const result = await pg.mint({ avatar: AVATAR });
+
+    expect(result.amount).toBe(0n);
+    expect(result.txs).toHaveLength(0);
+  });
+
+  test('non-zero claimable issuance still builds the full mint batch (short-circuit does not fire)', async () => {
+    // issuance 1000 × score 50 / 100 = 500 → a real mint.
+    const pg = makeGroup({ scoreRaw: '50', issuance: 1000n });
+
+    const result = await pg.mint({ avatar: AVATAR });
+
+    expect(result.amount).toBe(500n);
+    // snapshotIssuance → personalMint → groupMint → wrap (no trust prefix here).
+    expect(result.txs).toHaveLength(4);
+  });
+
+  test('explicit amount > 0 is honored regardless of issuance', async () => {
+    const pg = makeGroup({ scoreRaw: '50', issuance: 1000n });
+
+    const result = await pg.mint({ avatar: AVATAR, amount: 123n });
+
+    expect(result.amount).toBe(123n);
+    expect(result.txs).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## What

`PermissionlessGroup.mint()` threw `SCORE_GROUPS_INVALID_INPUT`
("mint-max resolved to 0: avatar has no claimable issuance right now") whenever
an avatar requested the maximum mint (`amount` omitted or `0n`) but had no
claimable personal issuance at that moment.

That is a normal, transient state: personal issuance accrues over time, so an
avatar that just minted has ~0 and `(issuance * score) / 100` floors to `0`.
Throwing turned a routine "nothing to mint right now" into a hard error.

## Change

- `resolveAmount()` returns `0n` for that case instead of throwing.
- `buildMintBatch()` short-circuits a `0` resolve to an empty batch
  `{ txs: [], proof, amount: 0n }`, matching how `migration()` and the
  `scoreRaw === "0"` path in `mint()` already represent "nothing to do".

No change to the happy path (issuance > 0 builds the full
trust/snapshot/personalMint/groupMint/wrap batch) or to explicit `amount > 0n` mints.

## Caller contract change (action required by consumers)

This converts a **throw** into an **empty result**. Consumers that relied on the
thrown error must guard the empty batch before submitting:

```ts
const { txs, amount } = await group.mint({ avatar });
if (amount === 0n || txs.length === 0) {
  // nothing to mint right now — show a friendly state, don't submit
  return;
}
// ... submit txs
```

This is the same guard consumers already need for `migration()` (which returns
`{ txs: [], amount: 0n }` when nothing is migratable) and the `scoreRaw === "0"`
mint path. Adopt this guard in the same release that bumps to the version
carrying this change.

## Tests

`packages/permissionless-groups/src/tests/mint.test.ts`:
- mint-max with zero issuance → empty batch, no throw
- tiny issuance that integer-floors the mintable to 0 → empty batch, no throw
- `scoreRaw === "0"` → unchanged personalMint-only batch
- happy path (issuance > 0) → full batch, short-circuit does not fire
- explicit `amount > 0` honored

**Test plan**
- [ ] `bun run build` (workspace builds; permissionless-groups typechecks, incl. tests)
- [ ] `bun test packages/permissionless-groups/src/tests/mint.test.ts` (5 pass)
