### PR TITLE
feat(rpc): add getTransferData reader for transfer annotations

### DIFF
--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -28,7 +28,7 @@ export type {
 } from './types.js';
 
 // Re-export shared types from @aboutcircles/sdk-types for convenience
-export type { TrustRelationType, AggregatedTrustRelation } from '@aboutcircles/sdk-types';
+export type { TrustRelationType, AggregatedTrustRelation, TransferDataRow } from '@aboutcircles/sdk-types';
 
 // Error handling
 export { RpcError } from './errors.js';

--- a/packages/rpc/src/methods/transaction.ts
+++ b/packages/rpc/src/methods/transaction.ts
@@ -1,5 +1,5 @@
 import type { RpcClient } from '../client.js';
-import type { Address, TransactionHistoryRow, EnrichedTransaction, PagedResponse } from '@aboutcircles/sdk-types';
+import type { Address, TransactionHistoryRow, TransferDataRow, EnrichedTransaction, PagedResponse } from '@aboutcircles/sdk-types';
 import { normalizeAddress, checksumAddresses } from '../utils.js';
 
 /**
@@ -64,6 +64,60 @@ export class TransactionMethods {
       'circles_getTransactionHistoryEnriched',
       [normalizeAddress(avatar), fromBlock, toBlock, limit, cursor ?? null]
     );
+
+    return {
+      hasMore: response.hasMore,
+      nextCursor: response.nextCursor,
+      results: checksumAddresses(response.results),
+    };
+  }
+
+  /**
+   * Get transfer-data annotations for an address.
+   *
+   * Annotations are blobs carried in the `data` of an ERC-1155 `safeTransferFrom` — including
+   * the 0-value transfer batched alongside a gCRC/ERC-20 transfer to annotate it. The indexer
+   * stores each as a row keyed by `(transactionHash, from, to)`; decode `row.data` with
+   * `decodeCrcV2TransferData` from `@aboutcircles/sdk-utils`.
+   *
+   * @param address - Address whose annotations to query
+   * @param direction - 'sent', 'received', or null/omitted for both
+   * @param counterparty - Restrict to annotations exchanged with this address
+   * @param fromBlock - Only annotations at or after this block
+   * @param toBlock - Only annotations at or before this block
+   * @param limit - Maximum rows to return (default: 50)
+   * @param cursor - Keyset pagination cursor
+   * @returns Paged response of transfer-data rows (newest first)
+   *
+   * @example
+   * ```typescript
+   * const page = await rpc.transaction.getTransferData('0xAvatar...', 'sent');
+   * page.results.forEach(r => console.log(r.transactionHash, decodeCrcV2TransferData(r.data)));
+   * ```
+   */
+  async getTransferData(
+    address: Address,
+    direction?: 'sent' | 'received' | null,
+    counterparty?: Address | null,
+    fromBlock?: number | null,
+    toBlock?: number | null,
+    limit: number = 50,
+    cursor?: string | null
+  ): Promise<PagedResponse<TransferDataRow>> {
+    // Param order must match the plugin signature exactly: address, direction, counterparty,
+    // fromBlock, toBlock, limit, cursor (common filters before block range).
+    const response = await this.client.call<
+      [Address, string | null, Address | null, number | null, number | null, number, string | null],
+      PagedResponse<TransferDataRow>
+    >('circles_getTransferData', [
+      normalizeAddress(address),
+      direction ?? null,
+      counterparty ? normalizeAddress(counterparty) : null,
+      fromBlock ?? null,
+      toBlock ?? null,
+      limit,
+      cursor ?? null,
+    ]);
 
     return {
       hasMore: response.hasMore,

--- a/packages/rpc/src/tests/getTransferData.test.ts
+++ b/packages/rpc/src/tests/getTransferData.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'bun:test';
+import { TransactionMethods } from '../methods/transaction.js';
+import type { RpcClient } from '../client.js';
+import type { Address, PagedResponse, TransferDataRow } from '@aboutcircles/sdk-types';
+
+// Checksummed/lowercase pairs reused across cases.
+const ADDR_CS = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed' as Address;
+const ADDR_LC = '0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaed';
+const COUNTER_CS = '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359' as Address;
+const COUNTER_LC = '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359';
+
+/** Minimal RpcClient stub that records calls and returns a fixed result. */
+function mockClient(result: PagedResponse<TransferDataRow>) {
+  const calls: { method: string; params: unknown }[] = [];
+  const client = {
+    call: async (method: string, params: unknown) => {
+      calls.push({ method, params });
+      return result;
+    },
+  } as unknown as RpcClient;
+  return { client, calls };
+}
+
+const emptyPage: PagedResponse<TransferDataRow> = { results: [], hasMore: false, nextCursor: null };
+
+describe('TransactionMethods.getTransferData', () => {
+  test('marshals all params in the plugin order, lowercasing addresses', async () => {
+    const { client, calls } = mockClient(emptyPage);
+    const tx = new TransactionMethods(client);
+
+    await tx.getTransferData(ADDR_CS, 'sent', COUNTER_CS, 100, 200, 25, 'cursor-1');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('circles_getTransferData');
+    // address, direction, counterparty, fromBlock, toBlock, limit, cursor
+    expect(calls[0].params).toEqual([ADDR_LC, 'sent', COUNTER_LC, 100, 200, 25, 'cursor-1']);
+  });
+
+  test('applies defaults (both directions, no filters, limit 50)', async () => {
+    const { client, calls } = mockClient(emptyPage);
+    const tx = new TransactionMethods(client);
+
+    await tx.getTransferData(ADDR_CS);
+
+    expect(calls[0].params).toEqual([ADDR_LC, null, null, null, null, 50, null]);
+  });
+
+  test('checksums from/to in results and passes the data blob through untouched', async () => {
+    const data = '0x010001002f676f7420796f757220474e4f206261636b2e' as `0x${string}`;
+    const { client } = mockClient({
+      results: [
+        {
+          blockNumber: 46653686,
+          timestamp: 1700000000,
+          transactionIndex: 9,
+          logIndex: -1,
+          transactionHash: '0xabc' as `0x${string}`,
+          from: ADDR_LC as Address,
+          to: COUNTER_LC as Address,
+          data,
+        },
+      ],
+      hasMore: true,
+      nextCursor: 'next',
+    });
+    const tx = new TransactionMethods(client);
+
+    const page = await tx.getTransferData(ADDR_CS, 'sent');
+
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).toBe('next');
+    expect(page.results[0].from).toBe(ADDR_CS);
+    expect(page.results[0].to).toBe(COUNTER_CS);
+    expect(page.results[0].data).toBe(data); // hex blob is longer than 40 chars → never mistaken for an address
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -40,7 +40,7 @@ export type {
   InvitationsFromResponse,
   AllInvitationsResponse
 } from './rpc-responses.js';
-export type { TransactionHistoryRow } from './rows.js';
+export type { TransactionHistoryRow, TransferDataRow } from './rows.js';
 
 // Query and filter types
 export type {

--- a/packages/types/src/rows.ts
+++ b/packages/types/src/rows.ts
@@ -19,3 +19,25 @@ export interface TransactionHistoryRow {
   staticCircles: string;
   staticAttoCircles: string;
 }
+
+/**
+ * A transfer-data annotation row, as returned by `circles_getTransferData`.
+ *
+ * Annotations are carried in the `data` bytes of an ERC-1155 `safeTransferFrom`
+ * (including the 0-value transfer used to annotate a gCRC/ERC-20 transfer). The indexer
+ * extracts them from calldata and stores them keyed by `(transactionHash, from, to)` — there
+ * is no explicit link to a specific value transfer, so correlate by those fields. Decode
+ * `data` with `decodeCrcV2TransferData` from `@aboutcircles/sdk-utils`.
+ */
+export interface TransferDataRow {
+  blockNumber: number;
+  timestamp: number;
+  transactionIndex: number;
+  /** Synthetic, negative for calldata-derived events (no real log emitted the data). */
+  logIndex: number;
+  transactionHash: Hex;
+  from: Address;
+  to: Address;
+  /** 0x-prefixed hex annotation blob; decode with `decodeCrcV2TransferData`. */
+  data: Hex;
+}


### PR DESCRIPTION
## Summary

Adds a typed SDK wrapper for the `circles_getTransferData` JSON-RPC method, which returns the data blobs ("annotations") the indexer extracts from the `data` bytes of ERC-1155 `safeTransferFrom` transfers.

Background: ERC-20 (gCRC) transfers have no `data` field, so an annotation for a gCRC transfer is carried by an extra **0-value ERC-1155 `safeTransferFrom`** batched into the same transaction. The indexer parses that `data` from calldata and stores it keyed by `(transactionHash, from, to)`. The SDK already had `encodeCrcV2TransferData`/`decodeCrcV2TransferData`; this adds the missing read side.

## What changed

- **types**: add `TransferDataRow` (`blockNumber, timestamp, transactionIndex, logIndex, transactionHash, from, to, data`) in `packages/types/src/rows.ts`, exported from the package index.
- **rpc**: `TransactionMethods.getTransferData(address, direction?, counterparty?, fromBlock?, toBlock?, limit?, cursor?)` -> `PagedResponse<TransferDataRow>`. Mirrors `getTransactionHistory`: param order matches the indexer signature exactly, addresses normalized to lowercase on input and EIP-55 checksummed on output; the hex `data` blob is passed through untouched.
- re-export `TransferDataRow` from `@aboutcircles/sdk-rpc`.
- unit tests covering param marshalling, defaults, and result checksumming.

Decode `row.data` with `decodeCrcV2TransferData` from `@aboutcircles/sdk-utils`.

## Test plan

- [x] `bun test packages/rpc/src/tests/getTransferData.test.ts` — 3 pass / 0 fail
- [x] No-network rpc unit suite (checksumAddresses, backward-compat, new) — 22 pass / 0 fail (10 skip: require localhost RPC)
- [x] `bunx tsc --build` (all packages) — clean
- [x] `bun run build:rpc` (bundle + declarations) — clean
- [x] Live round-trip against rpc.aboutcircles.com: `getTransferData` returns rows that `decodeCrcV2TransferData` decodes to the expected annotations