### PR TITLE
feat(rpc): add pathfinder.findScoreGroupRedeemPath for score-group gCRC redeem capacity

### DIFF
--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -115,6 +115,10 @@ const events = await rpc.query.events(
   - **params**: `{ from, to, targetFlow, useWrappedBalances?, fromTokens?, toTokens?, excludeFromTokens?, excludeToTokens?, simulatedBalances? }`
   - All amounts are `bigint`, addresses normalized to lowercase
   - Returns path with `flow` and `transfers` (all amounts as `bigint`)
+- `findScoreGroupRedeemPath(params): Promise<PathfindingResult>` - Compute how much of a score group's gCRC a holder can redeem back into the backing collateral (self-redeem: source == sink == holder)
+  - **params**: `{ group, holder, amount? }` — `amount` is an optional `bigint` cap (CRC wei); omit to redeem up to the holder's full gCRC balance
+  - Same `MaxFlowResponse` shape as `findPath` (`{ maxFlow, transfers }`, amounts as `bigint`): one collateral leg (treasury → holder) per allocated collateral, clamped per collateral by `MIN(holder entitlement, treasury holding)`
+  - **Note**: a forward-looking pre-flight — no on-chain redeem path is deployed yet, so the per-collateral selection order is a server-side placeholder; amounts/clamping are final
 
 ### Query Methods
 

--- a/packages/rpc/src/methods/pathfinder.ts
+++ b/packages/rpc/src/methods/pathfinder.ts
@@ -1,6 +1,15 @@
 import type { RpcClient } from '../client.js';
-import type { FindPathParams, PathfindingResult } from '@aboutcircles/sdk-types';
-import { normalizeFindPathParams, parseStringsToBigInt, checksumAddresses } from '../utils.js';
+import type {
+  FindPathParams,
+  FindScoreGroupRedeemPathParams,
+  PathfindingResult,
+} from '@aboutcircles/sdk-types';
+import {
+  normalizeAddress,
+  normalizeFindPathParams,
+  parseStringsToBigInt,
+  checksumAddresses,
+} from '../utils.js';
 import { MAX_FLOW } from '@aboutcircles/sdk-utils/constants';
 
 /**
@@ -56,5 +65,56 @@ export class PathfinderMethods {
       targetFlow: MAX_FLOW
     });
     return BigInt(path.maxFlow);
+  }
+
+  /**
+   * Compute the redeem capacity of a score group's gCRC back into its backing collateral.
+   *
+   * The holder is both source and sink (a self-redeem): the result decomposes how much of the
+   * holder's gCRC can be converted into each collateral, clamped per collateral by what the
+   * group's on-chain ScoreTreasury actually holds — `MIN(holder entitlement, treasury holding)`.
+   *
+   * The response is a {@link PathfindingResult} (same shape as {@link findPath}): `transfers`
+   * lists one collateral leg (treasury → holder) per allocated collateral and `maxFlow` is the
+   * total redeemable gCRC (== the sum of the collateral legs, 1:1). No gCRC burn leg is emitted —
+   * `maxFlow` already states how much gCRC to redeem.
+   *
+   * Note: no on-chain redeem path is deployed yet, so the per-collateral selection order is a
+   * server-side placeholder (greedy, largest treasury holding first). The amounts and clamping are
+   * final; the executable `from`/`to` legs are finalized once the redeem contract ships.
+   *
+   * @param params - `group` (gCRC being redeemed), `holder` (redeemer), optional `amount` cap
+   * @returns The redeem decomposition with collateral transfers (amounts as bigint)
+   *
+   * @example
+   * ```typescript
+   * const redeem = await rpc.pathfinder.findScoreGroupRedeemPath({
+   *   group: '0x93ed5a96347927ff6ff6b790f8cf5258240c321f',
+   *   holder: '0x665a55a3ab1de41853cf808df40d112824092534',
+   *   // amount omitted → redeem up to the holder's full gCRC balance
+   * });
+   * ```
+   */
+  async findScoreGroupRedeemPath(
+    params: FindScoreGroupRedeemPathParams
+  ): Promise<PathfindingResult> {
+    // The server binds params positionally: [group, holder, amount?]. Omit the trailing `amount`
+    // when undefined so the server applies its default (full balance) — sending null would work
+    // too, but an omitted optional is the cleaner wire form.
+    const wireParams: string[] = [
+      normalizeAddress(params.group),
+      normalizeAddress(params.holder),
+    ];
+    if (params.amount !== undefined) {
+      wireParams.push(params.amount.toString());
+    }
+
+    const result = await this.client.call<string[], Record<string, unknown>>(
+      'circles_findScoreGroupRedeemPath',
+      wireParams
+    );
+
+    const parsed = parseStringsToBigInt(result) as unknown as PathfindingResult;
+    return checksumAddresses(parsed);
   }
 }

--- a/packages/rpc/src/tests/scoreGroupRedeem.integration.test.ts
+++ b/packages/rpc/src/tests/scoreGroupRedeem.integration.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from 'bun:test';
+import { CirclesRpc } from '../rpc';
+import { RpcError } from '../errors.js';
+import type { Address } from '@aboutcircles/sdk-types';
+
+// Live integration test for circles_findScoreGroupRedeemPath.
+//
+// Opt-in: point CIRCLES_RPC_URL at an endpoint that exposes the method (it is being rolled out, so
+// not every RPC has it yet). The test auto-skips when the endpoint is unreachable or returns
+// -32601 (method not found), so it is safe to run against any RPC. Group/holder are public on-chain
+// addresses and can be overridden via env for a different deployment.
+const env = ((globalThis as Record<string, unknown>).process as { env?: Record<string, string | undefined> } | undefined)?.env ?? {};
+const RPC_URL = env.CIRCLES_RPC_URL ?? 'http://localhost:8081/';
+const GROUP = (env.SCOREGROUP_REDEEM_GROUP ?? '0x93ed5a96347927ff6ff6b790f8cf5258240c321f') as Address;
+const HOLDER = (env.SCOREGROUP_REDEEM_HOLDER ?? '0x665a55a3ab1de41853cf808df40d112824092534') as Address;
+const TEST_TIMEOUT = Number(env.CIRCLES_RPC_TEST_TIMEOUT ?? 45000);
+
+const rpc = new CirclesRpc(RPC_URL);
+let methodAvailable = true;
+
+try {
+  // A successful response (even maxFlow "0") proves the method is served; only -32601 / connection
+  // failures mean it is unavailable on this endpoint.
+  await rpc.pathfinder.findScoreGroupRedeemPath({ group: GROUP, holder: HOLDER });
+} catch (error) {
+  const code = error instanceof RpcError ? (error.context as { data?: unknown })?.data : undefined;
+  methodAvailable = false;
+  console.warn(
+    `[scoregroup-redeem] Integration tests skipped - method unavailable at ${RPC_URL}: ${(error as Error).message}${code ? ` (code ${String(code)})` : ''}`
+  );
+}
+
+const integration = methodAvailable ? describe : describe.skip;
+
+integration('findScoreGroupRedeemPath (live)', () => {
+  test('full balance: decomposition is well-formed and conserves the total', async () => {
+    const result = await rpc.pathfinder.findScoreGroupRedeemPath({ group: GROUP, holder: HOLDER });
+
+    expect(typeof result.maxFlow).toBe('bigint');
+    expect(result.maxFlow).toBeGreaterThanOrEqual(0n);
+    expect(Array.isArray(result.transfers)).toBe(true);
+
+    let sum = 0n;
+    for (const leg of result.transfers) {
+      expect(typeof leg.value).toBe('bigint');
+      expect(leg.value).toBeGreaterThan(0n);
+      // Every collateral leg is delivered to the holder (self-redeem: source == sink == holder).
+      expect(leg.to.toLowerCase()).toBe(HOLDER.toLowerCase());
+      expect(typeof leg.from).toBe('string');
+      expect(typeof leg.tokenOwner).toBe('string');
+      sum += leg.value;
+    }
+    // maxFlow == sum of collateral legs (1:1 redeem decomposition).
+    expect(sum).toBe(result.maxFlow);
+  }, TEST_TIMEOUT);
+
+  test('amount cap clamps maxFlow to at most the requested amount', async () => {
+    const cap = 5n;
+    const result = await rpc.pathfinder.findScoreGroupRedeemPath({
+      group: GROUP,
+      holder: HOLDER,
+      amount: cap,
+    });
+
+    expect(result.maxFlow).toBeLessThanOrEqual(cap);
+  }, TEST_TIMEOUT);
+
+  test('negative amount is rejected by the server (-32602)', async () => {
+    await expect(
+      rpc.pathfinder.findScoreGroupRedeemPath({ group: GROUP, holder: HOLDER, amount: -5n })
+    ).rejects.toBeInstanceOf(RpcError);
+  }, TEST_TIMEOUT);
+});

--- a/packages/rpc/src/tests/scoreGroupRedeem.test.ts
+++ b/packages/rpc/src/tests/scoreGroupRedeem.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from 'bun:test';
+import type { RpcClient } from '../client.js';
+import { PathfinderMethods } from '../methods/pathfinder.js';
+import { checksumAddress } from '../utils.js';
+import type { Address } from '@aboutcircles/sdk-types';
+
+// Mixed-case-checksum addresses so we can prove the result is checksummed (not echoed lowercase).
+const GROUP = '0x93ed5a96347927ff6ff6b790f8cf5258240c321f' as Address;
+const HOLDER = '0x665a55a3ab1de41853cf808df40d112824092534' as Address;
+const TREASURY = '0xe445d6f2c5af0b0c6f9b9b9b9b9b9b9b9b9b41ce' as Address;
+const COLLATERAL = '0x8b8837e3a2c0f9b9b9b9b9b9b9b9b9b9b9b9e3a2' as Address;
+
+/**
+ * Build a PathfinderMethods backed by a stub client that records the last call and
+ * returns a canned server-shaped (all-strings) MaxFlowResponse.
+ */
+function makePathfinder(serverResult: Record<string, unknown>) {
+  const calls: { method: string; params: unknown }[] = [];
+  const stub = {
+    call: async (method: string, params: unknown) => {
+      calls.push({ method, params });
+      return serverResult;
+    },
+  } as unknown as RpcClient;
+  return { pathfinder: new PathfinderMethods(stub), calls };
+}
+
+const ONE_LEG_RESULT = {
+  maxFlow: '75',
+  transfers: [
+    { from: TREASURY, to: HOLDER, tokenOwner: COLLATERAL, value: '75' },
+  ],
+};
+
+describe('PathfinderMethods.findScoreGroupRedeemPath', () => {
+  test('calls circles_findScoreGroupRedeemPath with positional params', async () => {
+    const { pathfinder, calls } = makePathfinder(ONE_LEG_RESULT);
+
+    await pathfinder.findScoreGroupRedeemPath({ group: GROUP, holder: HOLDER });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('circles_findScoreGroupRedeemPath');
+    expect(Array.isArray(calls[0].params)).toBe(true);
+  });
+
+  test('omits the trailing amount when undefined', async () => {
+    const { pathfinder, calls } = makePathfinder(ONE_LEG_RESULT);
+
+    await pathfinder.findScoreGroupRedeemPath({ group: GROUP, holder: HOLDER });
+
+    // [group, holder] — no third element, so the server applies its full-balance default.
+    expect(calls[0].params).toEqual([GROUP.toLowerCase(), HOLDER.toLowerCase()]);
+  });
+
+  test('includes amount as a decimal string when provided', async () => {
+    const { pathfinder, calls } = makePathfinder(ONE_LEG_RESULT);
+
+    await pathfinder.findScoreGroupRedeemPath({
+      group: GROUP,
+      holder: HOLDER,
+      amount: 1000000000000000000n,
+    });
+
+    expect(calls[0].params).toEqual([
+      GROUP.toLowerCase(),
+      HOLDER.toLowerCase(),
+      '1000000000000000000',
+    ]);
+  });
+
+  test('serializes amount === 0n explicitly (not omitted)', async () => {
+    const { pathfinder, calls } = makePathfinder({ maxFlow: '0', transfers: [] });
+
+    await pathfinder.findScoreGroupRedeemPath({ group: GROUP, holder: HOLDER, amount: 0n });
+
+    // 0n is a real cap (redeem nothing), distinct from "omitted" → must be sent as "0".
+    expect(calls[0].params).toEqual([GROUP.toLowerCase(), HOLDER.toLowerCase(), '0']);
+  });
+
+  test('lowercases mixed-case input addresses on the wire', async () => {
+    const { pathfinder, calls } = makePathfinder(ONE_LEG_RESULT);
+
+    await pathfinder.findScoreGroupRedeemPath({
+      group: checksumAddress(GROUP),
+      holder: checksumAddress(HOLDER),
+    });
+
+    const params = calls[0].params as string[];
+    expect(params[0]).toBe(GROUP.toLowerCase());
+    expect(params[1]).toBe(HOLDER.toLowerCase());
+  });
+
+  test('parses string amounts to bigint and checksums addresses in the result', async () => {
+    const { pathfinder } = makePathfinder(ONE_LEG_RESULT);
+
+    const result = await pathfinder.findScoreGroupRedeemPath({ group: GROUP, holder: HOLDER });
+
+    expect(typeof result.maxFlow).toBe('bigint');
+    expect(result.maxFlow).toBe(75n);
+    expect(result.transfers).toHaveLength(1);
+    expect(typeof result.transfers[0].value).toBe('bigint');
+    expect(result.transfers[0].value).toBe(75n);
+    // Addresses come back EIP-55 checksummed, identical to findPath's post-processing.
+    expect(result.transfers[0].from).toBe(checksumAddress(TREASURY));
+    expect(result.transfers[0].to).toBe(checksumAddress(HOLDER));
+    expect(result.transfers[0].tokenOwner).toBe(checksumAddress(COLLATERAL));
+  });
+
+  test('handles an empty redeem (no entitlement / nothing to redeem)', async () => {
+    const { pathfinder } = makePathfinder({ maxFlow: '0', transfers: [] });
+
+    const result = await pathfinder.findScoreGroupRedeemPath({ group: GROUP, holder: HOLDER });
+
+    expect(result.maxFlow).toBe(0n);
+    expect(result.transfers).toEqual([]);
+  });
+});

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -78,6 +78,7 @@ export type {
   SimulatedBalance,
   SimulatedTrust,
   FindPathParams,
+  FindScoreGroupRedeemPathParams,
   TransferStep,
   PathfindingResult,
   FlowEdgeStruct,

--- a/packages/types/src/pathfinding.ts
+++ b/packages/types/src/pathfinding.ts
@@ -41,6 +41,29 @@ export interface FindPathParams {
 }
 
 /**
+ * Parameters for circles_findScoreGroupRedeemPath.
+ *
+ * Computes how much of a score group's gCRC `holder` can redeem back into the
+ * backing collateral (source == sink == holder, fromToken == the group's gCRC),
+ * decomposed per collateral. The result is a {@link PathfindingResult} — the same
+ * shape as {@link FindPathParams}'s `findPath` — so it consumes identically.
+ *
+ * Per collateral the redeemable amount is `MIN(holder entitlement, treasury holding)`.
+ * The entitlement is the holder's demurraged gCRC balance, optionally capped by `amount`.
+ */
+export interface FindScoreGroupRedeemPathParams {
+  /** Score group address whose gCRC is being redeemed back into collateral. */
+  group: Address;
+  /** Holder/redeemer address (acts as both source and sink of the redeem). */
+  holder: Address;
+  /**
+   * Optional uint256 cap (CRC wei) on the gCRC to redeem.
+   * Omit to redeem up to the holder's full demurraged balance.
+   */
+  amount?: bigint;
+}
+
+/**
  * A single transfer step in a pathfinding result
  */
 export interface TransferStep {


### PR DESCRIPTION
## Summary

Adds `rpc.pathfinder.findScoreGroupRedeemPath(...)` — a client binding for the `circles_findScoreGroupRedeemPath` JSON-RPC method. It computes how much of a score group's gCRC a holder can redeem back into the backing collateral (a self-redeem: `source == sink == holder`, `fromToken` = the group's gCRC), decomposed per collateral.

The response is a `PathfindingResult` — the exact same `{ maxFlow, transfers }` shape as `findPath` — so it consumes identically and reuses the existing `parseStringsToBigInt` + `checksumAddresses` post-processing. Per collateral the redeemable amount is `MIN(holder entitlement, treasury holding)`; `maxFlow` equals the sum of the collateral legs (1:1).

## What changed

- `packages/types`: new `FindScoreGroupRedeemPathParams` interface (`{ group, holder, amount? }`), exported from the package root.
- `packages/rpc`: `PathfinderMethods.findScoreGroupRedeemPath()`. The server binds this method's params **positionally** (`[group, holder, amount?]`), unlike `findPath`'s single named-object param. The trailing `amount` is omitted when `undefined` so the server applies its default (full balance); `0n` is sent explicitly as `"0"` (a real "redeem nothing" cap). Addresses are lowercased on the wire.
- Surfaced for free on the high-level SDK via `sdk.rpc.pathfinder.findScoreGroupRedeemPath(...)` (no extra wiring).
- README + JSDoc updated.

## API

```ts
const redeem = await rpc.pathfinder.findScoreGroupRedeemPath({
  group:  '0x…',   // score group whose gCRC is being redeemed
  holder: '0x…',   // redeemer (source == sink)
  amount: 1_000_000_000_000_000_000n, // optional CRC-wei cap; omit for full balance
});
// → { maxFlow: bigint, transfers: { from, to, tokenOwner, value: bigint }[] }
```

## Rollout note

`circles_findScoreGroupRedeemPath` is being rolled out and is not yet present on every RPC endpoint. Against an endpoint that does not serve it, the call returns `-32601 (method not found)` as a thrown `RpcError`. Hold any release of this client until the method is available on the default endpoint.

It is also a forward-looking pre-flight: no on-chain redeem path is deployed yet, so the per-collateral selection order is a server-side placeholder. The amounts and clamping are final.

## Test plan

- [x] `bun run build` — full workspace, 0 errors
- [x] Unit tests (`packages/rpc/src/tests/scoreGroupRedeem.test.ts`, 7 tests): positional wire serialization, `amount` omitted vs decimal string, `0n` sent as `"0"`, address lowercasing, `bigint` parsing, EIP-55 checksumming of the result.
- [x] Opt-in live integration test (`scoreGroupRedeem.integration.test.ts`): auto-skips unless `CIRCLES_RPC_URL` points at an endpoint exposing the method; verifies the decomposition conserves the total (`Σ legs == maxFlow`), every leg is delivered to the holder, the `amount` cap clamps `maxFlow`, and a negative amount is rejected (`-32602`). Run with:
  ```
  CIRCLES_RPC_URL=<rpc-exposing-the-method> bun test packages/rpc/src/tests/scoreGroupRedeem.integration.test.ts
  ```
- [x] Verified end-to-end against a live endpoint serving the method (full balance, capped amount, and negative-amount rejection all behave as expected).
