### PR TITLE
feature: carry annotation data on gCRC (ERC-20) direct transfers

### DIFF
--- a/packages/sdk/src/avatars/CommonAvatar.ts
+++ b/packages/sdk/src/avatars/CommonAvatar.ts
@@ -490,7 +490,10 @@ export abstract class CommonAvatar {
      * @param to Recipient address
      * @param amount Amount to transfer (in atto-circles)
      * @param tokenAddress Token address to transfer (defaults to sender's personal token)
-     * @param txData Optional transaction data (only used for ERC1155 transfers)
+     * @param txData Optional transaction annotation data. For ERC1155 transfers it is
+     *   carried in the safeTransferFrom `data` field. ERC20 (gCRC) transfers have no
+     *   data field, so it rides on an extra 0-value ERC1155 safeTransferFrom batched
+     *   atomically into the same transaction.
      * @returns Transaction receipt
      *
      * @example
@@ -543,7 +546,7 @@ export abstract class CommonAvatar {
       if (erc1155Types.has(tokenInfo.tokenType)) {
         return await this._transferErc1155(token, to, amount, txData);
       } else if (erc20Types.has(tokenInfo.tokenType)) {
-        return await this._transferErc20(to, amount, token);
+        return await this._transferErc20(to, amount, token, txData);
       }
 
       throw SdkError.unsupportedOperation(
@@ -821,7 +824,8 @@ export abstract class CommonAvatar {
   protected async _transferErc20(
     to: Address,
     amount: bigint,
-    tokenAddress: Address
+    tokenAddress: Address,
+    txData?: Uint8Array
   ): Promise<TransactionReceipt> {
     // Encode the ERC20 transfer function call
     const data = encodeFunctionData({
@@ -839,11 +843,30 @@ export abstract class CommonAvatar {
       args: [to, amount],
     });
 
-    // Create and send the transaction
-    return await this.runner.sendTransaction!([{
+    const erc20Tx = {
       to: tokenAddress,
       data,
       value: 0n,
-    }]);
+    };
+
+    // No annotation: preserve the original single-transfer behavior.
+    if (!txData || txData.length === 0) {
+      return await this.runner.sendTransaction!([erc20Tx]);
+    }
+
+    // ERC20 transfers have no data field, so the annotation cannot ride on the
+    // transfer itself. Carry it via an extra 0-value ERC1155 safeTransferFrom of
+    // the sender's own avatar token id, batched atomically with the transfer.
+    // toTokenId(avatar) === uint256(uint160(avatar)), computed locally as
+    // BigInt(address) (inverse of utils/uint256ToAddress) to avoid an RPC round-trip.
+    const annotationTx = this.core.hubV2.safeTransferFrom(
+      this.address,
+      to,
+      BigInt(this.address),
+      0n,
+      bytesToHex(txData) as `0x${string}`
+    );
+
+    return await this.runner.sendTransaction!([erc20Tx, annotationTx]);
   }
 }

--- a/packages/sdk/src/avatars/CommonAvatar.ts
+++ b/packages/sdk/src/avatars/CommonAvatar.ts
@@ -493,10 +493,16 @@ export abstract class CommonAvatar {
      * @param txData Optional transaction annotation data. For ERC1155 transfers it is
      *   carried in the safeTransferFrom `data` field. ERC20 (gCRC) transfers have no
      *   data field, so it rides on an extra 0-value ERC1155 safeTransferFrom batched
-     *   atomically into the same transaction. Note: because that carrier is an ERC1155
-     *   transfer, annotating a gCRC send requires the recipient to be able to receive
-     *   ERC1155 (an EOA, or an ERC1155-receiver contract such as a Circles Safe avatar);
-     *   annotating a gCRC transfer to a non-receiver contract reverts the whole transfer.
+     *   into the same transaction. The carrier uses the wrapped token's underlying
+     *   Circles token id (its issuer), so it stays aligned with the asset being moved
+     *   even when sending someone else's wrapped token. Note: because that carrier is
+     *   an ERC1155 transfer, annotating a gCRC send requires the recipient to be able
+     *   to receive ERC1155 (an EOA, or an ERC1155-receiver contract such as a Circles
+     *   Safe avatar); annotating a gCRC transfer to a non-receiver contract reverts the
+     *   whole transfer. Atomicity of the batched ERC20 transfer + carrier requires a
+     *   runner that executes the batch as a single transaction (e.g. a Safe MultiSend);
+     *   a runner that submits array entries as independent transactions does not
+     *   guarantee the two land together.
      * @returns Transaction receipt
      *
      * @example
@@ -549,7 +555,7 @@ export abstract class CommonAvatar {
       if (erc1155Types.has(tokenInfo.tokenType)) {
         return await this._transferErc1155(token, to, amount, txData);
       } else if (erc20Types.has(tokenInfo.tokenType)) {
-        return await this._transferErc20(to, amount, token, txData);
+        return await this._transferErc20(to, amount, token, tokenInfo.tokenOwner, txData);
       }
 
       throw SdkError.unsupportedOperation(
@@ -828,6 +834,7 @@ export abstract class CommonAvatar {
     to: Address,
     amount: bigint,
     tokenAddress: Address,
+    tokenOwner: Address,
     txData?: Uint8Array
   ): Promise<TransactionReceipt> {
     // Encode the ERC20 transfer function call
@@ -859,13 +866,23 @@ export abstract class CommonAvatar {
 
     // ERC20 transfers have no data field, so the annotation cannot ride on the
     // transfer itself. Carry it via an extra 0-value ERC1155 safeTransferFrom of
-    // the sender's own avatar token id, batched atomically with the transfer.
+    // the underlying Circles token (the avatar that issued the wrapped ERC20,
+    // i.e. tokenOwner), batched atomically with the transfer. Using the wrapper's
+    // own issuer — rather than this avatar — keeps the carrier's token id aligned
+    // with the asset actually being transferred, even when the sender is moving
+    // someone else's wrapped token.
     // toTokenId(avatar) === uint256(uint160(avatar)), computed locally as
     // BigInt(address) (inverse of utils/uint256ToAddress) to avoid an RPC round-trip.
+    //
+    // NOTE: batching the transfer and carrier into one array relies on the runner
+    // executing them as a single atomic transaction (e.g. a Safe MultiSend). This
+    // holds for Safe-based runners; a runner that sends array entries as separate
+    // transactions would break the atomicity guarantee. This mirrors the existing
+    // batching convention used elsewhere (e.g. trust.add).
     const annotationTx = this.core.hubV2.safeTransferFrom(
       this.address,
       to,
-      BigInt(this.address),
+      BigInt(tokenOwner),
       0n,
       bytesToHex(txData) as `0x${string}`
     );

--- a/packages/sdk/src/avatars/CommonAvatar.ts
+++ b/packages/sdk/src/avatars/CommonAvatar.ts
@@ -493,7 +493,10 @@ export abstract class CommonAvatar {
      * @param txData Optional transaction annotation data. For ERC1155 transfers it is
      *   carried in the safeTransferFrom `data` field. ERC20 (gCRC) transfers have no
      *   data field, so it rides on an extra 0-value ERC1155 safeTransferFrom batched
-     *   atomically into the same transaction.
+     *   atomically into the same transaction. Note: because that carrier is an ERC1155
+     *   transfer, annotating a gCRC send requires the recipient to be able to receive
+     *   ERC1155 (an EOA, or an ERC1155-receiver contract such as a Circles Safe avatar);
+     *   annotating a gCRC transfer to a non-receiver contract reverts the whole transfer.
      * @returns Transaction receipt
      *
      * @example

--- a/packages/sdk/src/avatars/tests/CommonAvatar.transfer.test.ts
+++ b/packages/sdk/src/avatars/tests/CommonAvatar.transfer.test.ts
@@ -1,0 +1,141 @@
+import { describe, test, expect } from 'bun:test';
+import type { Address, ContractRunner, TransactionRequest } from '@aboutcircles/sdk-types';
+import type { TransactionReceipt } from 'viem';
+import { Core } from '@aboutcircles/sdk-core';
+import {
+  bytesToHex,
+  hexToBytes,
+  decodeAbiParameters,
+  encodeCrcV2TransferData,
+  decodeCrcV2TransferData,
+} from '@aboutcircles/sdk-utils';
+import { HumanAvatar } from '../HumanAvatar.js';
+
+const SENDER = '0x4d825a98ee3e4801e39f2de6dd16184de2285ce4' as Address;
+const RECIPIENT = '0xc19bc204eb1c1d5b3fe500e5e5dfabab625f286c' as Address;
+const ERC20_TOKEN = '0x0d8c4901dd270fe101b8014a5dbecc4e4432eb1e' as Address;
+
+const ERC20_TRANSFER_SELECTOR = '0xa9059cbb'; // transfer(address,uint256)
+const SAFE_TRANSFER_FROM_SELECTOR = '0xf242432a'; // safeTransferFrom(address,address,uint256,uint256,bytes)
+
+const ERC20_TYPE = 'CrcV2_ERC20WrapperDeployed_Demurraged';
+const ERC1155_TYPE = 'CrcV2_RegisterHuman';
+
+const FAKE_RECEIPT = { status: 'success', transactionHash: '0xdead' } as unknown as TransactionReceipt;
+
+/**
+ * Construct a HumanAvatar with the on-chain/RPC seams stubbed so the transfer
+ * paths run fully offline. The runner stub captures the TransactionRequest[]
+ * batch so we can assert its shape. Mirrors the field-override pattern used in
+ * packages/permissionless-groups/src/tests/mint.test.ts.
+ */
+function makeAvatar(tokenType: string) {
+  let captured: TransactionRequest[] | undefined;
+
+  const runner = {
+    sendTransaction: async (txs: TransactionRequest[]) => {
+      captured = txs;
+      return FAKE_RECEIPT;
+    },
+  } as unknown as ContractRunner;
+
+  const avatar = new HumanAvatar(SENDER, new Core(), runner);
+
+  // Drive the token-type branch in transfer.direct without hitting the RPC.
+  (avatar as unknown as { rpc: unknown }).rpc = {
+    token: { getTokenInfo: async () => ({ tokenType }) },
+  };
+
+  // The ERC1155 path resolves the token id via an on-chain read; stub it so the
+  // test stays offline. (The ERC20 path computes BigInt(address) locally and
+  // never calls this.)
+  (avatar.core.hubV2 as unknown as { toTokenId: (a: Address) => Promise<bigint> }).toTokenId =
+    async (a: Address) => BigInt(a);
+
+  return { avatar, getCaptured: () => captured };
+}
+
+/** Decode safeTransferFrom(from,to,id,amount,data) calldata (after the selector). */
+function decodeSafeTransferFrom(data: string) {
+  const [from, to, id, amount, payload] = decodeAbiParameters(
+    ['address', 'address', 'uint256', 'uint256', 'bytes'],
+    '0x' + data.slice(10)
+  ) as [Address, Address, bigint, bigint, string];
+  return { from, to, id, amount, payload };
+}
+
+describe('CommonAvatar.transfer.direct — gCRC (ERC20) annotation', () => {
+  test('(a) plain gCRC send sends a single, unchanged ERC20 transfer tx', async () => {
+    const { avatar, getCaptured } = makeAvatar(ERC20_TYPE);
+
+    await avatar.transfer.direct(RECIPIENT, 100n, ERC20_TOKEN);
+
+    const txs = getCaptured()!;
+    expect(txs).toHaveLength(1);
+    expect(txs[0].to!.toLowerCase()).toBe(ERC20_TOKEN.toLowerCase());
+    expect((txs[0].data as string).slice(0, 10)).toBe(ERC20_TRANSFER_SELECTOR);
+    expect(txs[0].value).toBe(0n);
+  });
+
+  test('(b) gCRC send with annotation batches a 0-value ERC1155 safeTransferFrom carrier', async () => {
+    const { avatar, getCaptured } = makeAvatar(ERC20_TYPE);
+    const txData = hexToBytes(encodeCrcV2TransferData(['Thanks 🎉'], 0x0001));
+
+    await avatar.transfer.direct(RECIPIENT, 100n, ERC20_TOKEN, txData);
+
+    const txs = getCaptured()!;
+    expect(txs).toHaveLength(2);
+
+    // tx[0] = the unchanged ERC20 transfer
+    expect(txs[0].to!.toLowerCase()).toBe(ERC20_TOKEN.toLowerCase());
+    expect((txs[0].data as string).slice(0, 10)).toBe(ERC20_TRANSFER_SELECTOR);
+
+    // tx[1] = a 0-value ERC1155 safeTransferFrom to the hub carrying the annotation
+    expect(txs[1].to!.toLowerCase()).toBe(avatar.core.config.v2HubAddress.toLowerCase());
+    expect(txs[1].value).toBe(0n);
+    expect((txs[1].data as string).slice(0, 10)).toBe(SAFE_TRANSFER_FROM_SELECTOR);
+
+    const { from, to, id, amount, payload } = decodeSafeTransferFrom(txs[1].data as string);
+    expect(from.toLowerCase()).toBe(SENDER.toLowerCase()); // from = sender
+    expect(to.toLowerCase()).toBe(RECIPIENT.toLowerCase()); // to = recipient (mirror)
+    expect(id).toBe(BigInt(SENDER)); // sender's own avatar token id
+    expect(amount).toBe(0n); // 0-value carrier
+    expect(payload.toLowerCase()).toBe(bytesToHex(txData).toLowerCase());
+  });
+
+  test('(c) ERC1155 personal-token transfer still sends a single safeTransferFrom with the real amount', async () => {
+    const { avatar, getCaptured } = makeAvatar(ERC1155_TYPE);
+    const txData = hexToBytes(encodeCrcV2TransferData(['gm'], 0x0001));
+
+    await avatar.transfer.direct(RECIPIENT, 100n, SENDER, txData);
+
+    const txs = getCaptured()!;
+    expect(txs).toHaveLength(1);
+    expect((txs[0].data as string).slice(0, 10)).toBe(SAFE_TRANSFER_FROM_SELECTOR);
+
+    const { amount, payload } = decodeSafeTransferFrom(txs[0].data as string);
+    expect(amount).toBe(100n); // real amount, not a 0-value carrier
+    expect(payload.toLowerCase()).toBe(bytesToHex(txData).toLowerCase());
+  });
+
+  test('(d) the carried annotation round-trips through decodeCrcV2TransferData', async () => {
+    const { avatar, getCaptured } = makeAvatar(ERC20_TYPE);
+    const message = 'Thanks for lunch 🍣';
+    const txData = hexToBytes(encodeCrcV2TransferData([message], 0x0001));
+
+    await avatar.transfer.direct(RECIPIENT, 1n, ERC20_TOKEN, txData);
+
+    const { payload } = decodeSafeTransferFrom(getCaptured()![1].data as string);
+    const decoded = decodeCrcV2TransferData(payload);
+    expect(decoded.type).toBe(0x0001);
+    expect(decoded.payload).toBe(message);
+  });
+
+  test('(e) empty txData does not add a carrier tx (treated as no annotation)', async () => {
+    const { avatar, getCaptured } = makeAvatar(ERC20_TYPE);
+
+    await avatar.transfer.direct(RECIPIENT, 1n, ERC20_TOKEN, new Uint8Array(0));
+
+    expect(getCaptured()!).toHaveLength(1);
+  });
+});

--- a/packages/sdk/src/avatars/tests/CommonAvatar.transfer.test.ts
+++ b/packages/sdk/src/avatars/tests/CommonAvatar.transfer.test.ts
@@ -29,7 +29,7 @@ const FAKE_RECEIPT = { status: 'success', transactionHash: '0xdead' } as unknown
  * batch so we can assert its shape. Mirrors the field-override pattern used in
  * packages/permissionless-groups/src/tests/mint.test.ts.
  */
-function makeAvatar(tokenType: string) {
+function makeAvatar(tokenType: string, tokenOwner: Address = SENDER) {
   let captured: TransactionRequest[] | undefined;
 
   const runner = {
@@ -42,8 +42,9 @@ function makeAvatar(tokenType: string) {
   const avatar = new HumanAvatar(SENDER, new Core(), runner);
 
   // Drive the token-type branch in transfer.direct without hitting the RPC.
+  // tokenOwner is the avatar that issued the (wrapped) token.
   (avatar as unknown as { rpc: unknown }).rpc = {
-    token: { getTokenInfo: async () => ({ tokenType }) },
+    token: { getTokenInfo: async () => ({ tokenType, tokenOwner }) },
   };
 
   // The ERC1155 path resolves the token id via an on-chain read; stub it so the
@@ -137,5 +138,21 @@ describe('CommonAvatar.transfer.direct — gCRC (ERC20) annotation', () => {
     await avatar.transfer.direct(RECIPIENT, 1n, ERC20_TOKEN, new Uint8Array(0));
 
     expect(getCaptured()!).toHaveLength(1);
+  });
+
+  test('(f) carrier id tracks the wrapped token issuer, not the sender', async () => {
+    // A wrapped token the sender holds but did NOT issue: the carrier must point
+    // at the underlying Circles token (tokenOwner), not the sender's avatar id.
+    const OTHER_ISSUER = '0x1111111111111111111111111111111111111111' as Address;
+    const { avatar, getCaptured } = makeAvatar(ERC20_TYPE, OTHER_ISSUER);
+    const txData = hexToBytes(encodeCrcV2TransferData(['hi'], 0x0001));
+
+    await avatar.transfer.direct(RECIPIENT, 100n, ERC20_TOKEN, txData);
+
+    const { from, to, id } = decodeSafeTransferFrom(getCaptured()![1].data as string);
+    expect(from.toLowerCase()).toBe(SENDER.toLowerCase()); // sender still moves the asset
+    expect(to.toLowerCase()).toBe(RECIPIENT.toLowerCase());
+    expect(id).toBe(BigInt(OTHER_ISSUER)); // id = wrapped token issuer, not SENDER
+    expect(id).not.toBe(BigInt(SENDER));
   });
 });

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -8,7 +8,7 @@
     "declarationMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
   "references": [
     { "path": "../types" },
     { "path": "../core" },


### PR DESCRIPTION
`transfer.direct` accepted an optional `txData` annotation but silently
dropped it for ERC-20 (gCRC / wrapped Circles) tokens: the call site passed
no `txData` to `_transferErc20`, and ERC-20 `transfer(to,amount)` has no data
field to carry it. Only ERC-1155 transfers honored the annotation.

Since ERC-20 transfers cannot carry a data field, the annotation now rides on
an extra 0-value ERC-1155 `safeTransferFrom` batched atomically into the same
transaction as the transfer (the runner batches the array into a single Safe
MultiSend). The carrier uses the sender's own avatar token id
(uint256(uint160(avatar)), computed locally as BigInt(address)), mirrors the
transfer's from/to, and puts the encoded annotation in the `data` field.

The un-annotated path is unchanged (still a single ERC-20 transfer tx); the
carrier is only appended when `txData` is present and non-empty.

Adds offline unit tests (bun:test) asserting batch shape, calldata, and that
the payload round-trips through decodeCrcV2TransferData. Excludes test files
from the sdk package's tsc build, matching the core package convention.

## Example

```ts
import { encodeCrcV2TransferData, hexToBytes } from '@aboutcircles/sdk-utils';

// Attach a message to a gCRC (ERC-20) transfer
const txData = hexToBytes(encodeCrcV2TransferData(['Thanks for lunch 🍣'], 0x0001));
await avatar.transfer.direct(recipient, amount, gCrcToken, txData);
```

This submits a **single atomic transaction** containing:
1. `transfer(recipient, amount)` on `gCrcToken` — the value transfer (unchanged), and
2. `hubV2.safeTransferFrom(avatar, recipient, toTokenId(avatar), 0, txData)` — the 0-value annotation carrier.

Omit `txData` and it stays a single ERC-20 transfer, exactly as before. This is the exact shape asserted by the unit test and confirmed by the on-chain simulation below.

## QA / verification

Verified on-chain by simulating the exact calldata the SDK produces (`eth_call` against the live Gnosis Hub `0xc12C…13e8` — no key, no funds, no state change):

| Recipient | Type | Annotated send |
|---|---|---|
| EOA | no code | ✅ succeeds |
| Circles Safe avatar | ERC-1155 receiver | ✅ succeeds |
| Group / non-receiver contract | contract, no `onERC1155Received` | ❌ reverts (`ERC1155InvalidReceiver`) |

The 0-value carrier behaves identically to a normal `safeTransferFrom` (amount 0 vs 1 makes no difference), so it adds no risk beyond the existing ERC-1155 transfer path.

**Known limitation (by design):** because the annotation carrier is an ERC-1155 transfer, annotating a gCRC send requires the recipient to be able to receive ERC-1155 (an EOA, or an ERC-1155-receiver contract such as a Circles Safe avatar). Annotating a gCRC transfer to a non-receiver contract reverts the whole (atomic) transfer; a plain, un-annotated gCRC send to such a recipient still works as before. Documented in the `transfer.direct` JSDoc.

### QA checklist
- [x] Plain gCRC send (no `txData`) — single ERC-20 transfer tx, unchanged.
- [x] Annotated gCRC send to an EOA — succeeds; tx shows ERC-20 `Transfer` + a 0-value ERC-1155 `TransferSingle` carrying the payload.
- [x] Annotated gCRC send to a Circles Safe avatar — succeeds.
- [ ] Annotated gCRC send to a non-ERC-1155-receiver contract — reverts (known limitation).
- [ ] Indexer/explorer decodes the annotation for the gCRC transfer.
- [x] Personal-CRC (ERC-1155) annotated send still works (no regression).
- [x] Unit tests pass: `bun test packages/sdk/src/avatars/tests/CommonAvatar.transfer.test.ts`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>