### PR TITLE
feat(permissionless-groups): add per-token total to PersonalTokenBalance

### DIFF
--- a/packages/permissionless-groups/src/PermissionlessGroup.ts
+++ b/packages/permissionless-groups/src/PermissionlessGroup.ts
@@ -578,16 +578,8 @@ export class PermissionlessGroup {
       personalBalances,
       path.transfers,
     );
-    // Sum the breakdown in demurraged terms — inflationary entries are in
-    // static units, so convert before adding (mirrors `inflationaryErc20`).
-    const personalTotal = personalBreakdown.reduce(
-      (sum, p) =>
-        sum +
-        p.erc1155 +
-        p.demurrageErc20 +
-        CirclesConverter.attoStaticCirclesToAttoCircles(p.inflationaryErc20),
-      0n,
-    );
+    // Each entry's `total` is already the demurraged per-token sum.
+    const personalTotal = personalBreakdown.reduce((sum, p) => sum + p.total, 0n);
 
     return {
       scoreGroupBreakdown: {
@@ -652,6 +644,7 @@ export class PermissionlessGroup {
           erc1155: 0n,
           demurrageErc20: 0n,
           inflationaryErc20: 0n,
+          total: 0n,
         } satisfies PersonalTokenBalance);
 
       const outgoing = outgoingByToken.get(row.tokenAddress.toLowerCase()) ?? 0n;
@@ -670,9 +663,19 @@ export class PermissionlessGroup {
       byOwner.set(ownerKey, entry);
     }
 
-    return Array.from(byOwner.values()).filter(
-      (e) => e.erc1155 > 0n || e.demurrageErc20 > 0n || e.inflationaryErc20 > 0n,
-    );
+    // Roll up each token's forms into a single demurraged `total` (the
+    // inflationary form is static, so convert it down before adding).
+    return Array.from(byOwner.values())
+      .map((e) => ({
+        ...e,
+        total:
+          e.erc1155 +
+          e.demurrageErc20 +
+          CirclesConverter.attoStaticCirclesToAttoCircles(e.inflationaryErc20),
+      }))
+      .filter(
+        (e) => e.erc1155 > 0n || e.demurrageErc20 > 0n || e.inflationaryErc20 > 0n,
+      );
   }
 
   /**

--- a/packages/permissionless-groups/src/types.ts
+++ b/packages/permissionless-groups/src/types.ts
@@ -178,6 +178,12 @@ export interface PersonalTokenBalance {
   demurrageErc20: bigint;
   /** Transferable inflationary-wrapper ERC20 balance (inflationary/static): held − outgoing inflationary-ERC20 flow. */
   inflationaryErc20: bigint;
+  /**
+   * Sum of this token's three forms, normalized to **demurraged** atto-CRC
+   * (`inflationaryErc20` converted down first) — the avatar's total transferable
+   * balance of this token in a single comparable unit.
+   */
+  total: bigint;
 }
 
 /**


### PR DESCRIPTION
Each personalBreakdown entry now carries a demurraged `total` summing its three forms (inflationary converted down first). personalTotal is the sum of these.