### PR TITLE
feat(permissionless-groups): held-balance fields + migrateWithRetry

### DIFF
--- a/packages/permissionless-groups/src/PermissionlessGroup.ts
+++ b/packages/permissionless-groups/src/PermissionlessGroup.ts
@@ -39,6 +39,10 @@ import type {
   MintResult,
   MigrationParams,
   MigrationResult,
+  MigrationAttempt,
+  MigrationAttemptLog,
+  MigrationRetryOptions,
+  MigrationRetryResult,
   TransferGroupCrcParams,
   TransferGroupCrcResult,
   ProofResponse,
@@ -60,6 +64,25 @@ const clampScore = (raw: bigint): bigint => (raw > MAX_SCORE ? MAX_SCORE : raw);
 
 /** `a - b`, floored at 0 — never report a negative transferable balance. */
 const clampSub = (a: bigint, b: bigint): bigint => (a > b ? a - b : 0n);
+
+/**
+ * Default {@link MigrationRetryOptions.isRetryable}: a thrown `submit` error is
+ * retryable (a stale-route revert worth re-querying) UNLESS it's a user
+ * rejection/cancellation, or it isn't an `Error` at all (e.g. a programmer error
+ * in the callback) — those are fatal and rethrown rather than re-prompting the
+ * user with a smaller migration.
+ */
+function defaultIsRetryableSubmitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const m = error.message.toLowerCase();
+  const userCancelled =
+    m.includes("user rejected") ||
+    m.includes("user denied") ||
+    m.includes("rejected the request") ||
+    m.includes("request rejected") ||
+    m.includes("user cancel");
+  return !userCancelled;
+}
 
 /**
  * Default number of flow edges (`maxTransfers`) we ask the pathfinder for in
@@ -496,12 +519,14 @@ export class PermissionlessGroup {
    * Pathfinder → flow-matrix → tx batch. `params.amount` is forwarded
    * verbatim as the pathfinder `targetFlow`; omit it to request the
    * pathfinder's `MAX_FLOW` sentinel (everything the trust graph can route
-   * in one shot). `params.maxEdges` caps the number of flow edges (forwarded
-   * to the pathfinder's `maxTransfers`).
+   * in one shot). `params.maxEdges` is forwarded to the pathfinder's
+   * `maxTransfers` (it steers the search/splitting; it is not a hard cap on the
+   * returned edges — see {@link MigrationParams.maxEdges}).
    *
    * When nothing can be migrated (the pathfinder finds no route) — or only a
    * dust amount below {@link MigrationParams.dustThreshold} (default 0.1 CRC) —
-   * this returns an empty batch `{ txs: [], amount: 0n }` rather than throwing.
+   * this returns an empty batch `{ txs: [], amount: 0n, edges: 0 }` rather than
+   * throwing.
    * Migration being impossible (or not worth the gas) is a normal state, so
    * callers can simply check `txs.length`/`amount`. Submission is the caller's
    * job; the returned `txs` are meant to be sent atomically through a Safe runner.
@@ -509,13 +534,13 @@ export class PermissionlessGroup {
   async migration(params: MigrationParams): Promise<MigrationResult> {
     const path = await this.migrationPath(params);
     if (!path.transfers || path.transfers.length === 0) {
-      return { txs: [], amount: 0n };
+      return { txs: [], amount: 0n, edges: 0 };
     }
     // Skip dust: routing a sub-threshold amount through operateFlowMatrix costs
     // more gas than it's worth and only bloats the batch.
     const dustThreshold = params.dustThreshold ?? DEFAULT_MIGRATION_DUST_THRESHOLD;
     if (path.maxFlow < dustThreshold) {
-      return { txs: [], amount: 0n };
+      return { txs: [], amount: 0n, edges: 0 };
     }
 
     const scoreGroup = PERMISSIONLESS_GROUPS_MIGRATION.scoreGroupAddress;
@@ -531,7 +556,140 @@ export class PermissionlessGroup {
         useWrappedBalances: true,
       },
     );
-    return { txs: txs as TransactionRequest[], amount: path.maxFlow };
+    return {
+      txs: txs as TransactionRequest[],
+      amount: path.maxFlow,
+      edges: path.transfers.length,
+    };
+  }
+
+  /**
+   * Build + submit a migration with automatic re-query and hop-reduction retries.
+   *
+   * Migration routes through *intermediary* avatars' balances (transitive
+   * transfers), and that route goes stale within blocks — a batch built even
+   * seconds early can revert with `ERC20/ERC1155InsufficientBalance` once an
+   * intermediary moves. This helper hardens that on every attempt:
+   *
+   *   1. **Re-query fresh** — {@link migration} is called again right before each
+   *      submit, shrinking the staleness window to (ideally) one block.
+   *   2. **Shrink the edge cap on a retryable failure** — the next attempt caps
+   *      `maxEdges` at `floor(edgesUsed × reductionFactor)` (≥ `minEdges`),
+   *      routing a shorter path through fewer intermediaries: a little less
+   *      migrated for a much higher chance of landing.
+   *
+   * Submission stays runner-agnostic: `submit` sends the batch and must
+   * **throw/reject on revert**. Whether a thrown error is a *retryable* revert
+   * or a *fatal* error (user rejection, a bug in `submit`) is decided by
+   * {@link MigrationRetryOptions.isRetryable}; fatal errors are **rethrown
+   * immediately** rather than re-prompting the user with a smaller migration. A
+   * pathfinder/build error inside the loop is treated as retryable (logged, then
+   * retried), so it never discards the attempt log.
+   *
+   * Returns a discriminated {@link MigrationRetryResult}: `success: true` with the
+   * submit return value, or `success: false` with `reason: 'empty'` (nothing
+   * migratable / only dust — a smaller cap can't find more) or
+   * `reason: 'exhausted'` (real value, but every attempt reverted).
+   *
+   * @typeParam T - the submit callback's return type.
+   * @throws if an option is out of range, or on a non-retryable `submit` error.
+   */
+  async migrateWithRetry<T>(
+    params: MigrationParams,
+    submit: (txs: TransactionRequest[], attempt: MigrationAttempt) => Promise<T>,
+    options?: MigrationRetryOptions,
+  ): Promise<MigrationRetryResult<T>> {
+    const maxAttempts = options?.maxAttempts ?? 4;
+    const minEdges = options?.minEdges ?? 5;
+    const reductionFactor = options?.reductionFactor ?? 0.6;
+    const startEdges = options?.startEdges ?? params.maxEdges ?? DEFAULT_MAX_EDGES;
+    const isRetryable = options?.isRetryable ?? defaultIsRetryableSubmitError;
+
+    if (maxAttempts < 1) {
+      throw PermissionlessGroupError.invalidInput(
+        "migrateWithRetry() maxAttempts must be >= 1",
+        { maxAttempts },
+      );
+    }
+    if (minEdges < 1) {
+      throw PermissionlessGroupError.invalidInput(
+        "migrateWithRetry() minEdges must be >= 1",
+        { minEdges },
+      );
+    }
+    if (!(reductionFactor > 0 && reductionFactor < 1)) {
+      throw PermissionlessGroupError.invalidInput(
+        "migrateWithRetry() reductionFactor must be in the open interval (0, 1)",
+        { reductionFactor },
+      );
+    }
+    if (startEdges < minEdges) {
+      throw PermissionlessGroupError.invalidInput(
+        "migrateWithRetry() startEdges must be >= minEdges",
+        { startEdges, minEdges },
+      );
+    }
+
+    let nextEdges = startEdges;
+    const attempts: MigrationAttemptLog[] = [];
+
+    for (let i = 1; i <= maxAttempts; i++) {
+      const maxEdges = Math.max(minEdges, Math.floor(nextEdges));
+
+      // Fresh pathfinder query + rebuild on every attempt — the route is only
+      // valid for the current chain state, so we build as late as possible. A
+      // build/pathfinder error is transient-friendly: log it and retry rather
+      // than throw mid-loop and discard the attempt log.
+      let built: MigrationResult;
+      try {
+        built = await this.migration({ ...params, maxEdges });
+      } catch (err) {
+        attempts.push({
+          attempt: i,
+          maxEdges,
+          amount: 0n,
+          edges: 0,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        nextEdges = Math.floor(maxEdges * reductionFactor);
+        continue;
+      }
+
+      const info: MigrationAttempt = {
+        attempt: i,
+        maxEdges,
+        amount: built.amount,
+        edges: built.edges,
+      };
+
+      if (built.txs.length === 0) {
+        // Nothing migratable at this cap (no route, or only dust). A smaller cap
+        // can't find more, so stop rather than burn the remaining attempts.
+        attempts.push({ ...info, error: "no migratable route (empty batch)" });
+        return { success: false, reason: "empty", amount: 0n, attempts };
+      }
+
+      try {
+        const result = await submit(built.txs, info);
+        attempts.push(info);
+        return { success: true, result, amount: built.amount, attempts };
+      } catch (err) {
+        if (!isRetryable(err)) {
+          // Fatal (user rejection, a bug in `submit`, …): don't re-prompt with a
+          // smaller migration — surface the real error to the caller.
+          throw err;
+        }
+        attempts.push({
+          ...info,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        // Shrink based on the edges this failed route actually used, so the next
+        // attempt is a genuinely shorter (more robust) path.
+        nextEdges = Math.floor((built.edges || maxEdges) * reductionFactor);
+      }
+    }
+
+    return { success: false, reason: "exhausted", amount: 0n, attempts };
   }
 
   /**
@@ -559,36 +717,85 @@ export class PermissionlessGroup {
    * {@link DEFAULT_MAX_EDGES}`). Group-CRC figures are normalized to
    * **demurraged** atto-CRC so they're summable.
    *
-   * Also returns `personalBreakdown`: the avatar's held personal CRC (from
-   * `circles_getTokenBalances`, excluding the group's own token) with each
-   * form's amount reduced by the migration's outgoing flow that spent that
-   * form — i.e. what stays transferable after the migration counted in
-   * `migratable`. See {@link PersonalTokenBalance}.
+   * Returns both **deterministic** figures (`scoreGroupHeldTotal`,
+   * `personalHeldTotal`, and each breakdown entry's `heldTotal`) that depend
+   * only on the avatar's own holdings, and **live estimates**
+   * (`scoreGroupMigratable`, `scoreGroupTotal`, `personalTotal`, and the
+   * per-entry `total`) derived from the migration pathfinder — a network
+   * max-flow that tracks the indexer block (`migratableAtBlock`) and so changes
+   * between calls even when the avatar's holdings don't. See
+   * {@link GroupCrcBalance} for the full field-by-field contract.
+   *
+   * `personalBreakdown` lists the avatar's held personal CRC (from
+   * `circles_getTokenBalances`, excluding the group's own token); each entry's
+   * `total` is reduced by the migration's outgoing flow, while `heldTotal` is
+   * the raw held amount. See {@link PersonalTokenBalance}.
    *
    * Reads `balanceBreakdown(avatar)`, the migration pathfinder probe, and the
    * personal token balances in parallel. "Nothing migratable" (no path) counts
    * as `0`, not an error. For the raw per-form group-CRC breakdown + wrapper
    * addresses, use {@link balanceBreakdown}.
+   *
+   * @param options.includeMigratable - default `true`. Pass `false` to **skip
+   *   the migration pathfinder probe entirely** — faster, and avoids pulling a
+   *   live network max-flow you don't intend to show. With it off, the result is
+   *   fully deterministic: `scoreGroupMigratable` is `0n`, `scoreGroupTotal`
+   *   equals `scoreGroupHeldTotal`, `personalTotal` equals `personalHeldTotal`
+   *   (no outgoing flow is subtracted), and `migratableAtBlock` is omitted. Use
+   *   this for a stable balance display; only run with migratable on the
+   *   migrate/cashback action.
    */
-  async balance(avatar: Address): Promise<GroupCrcBalance> {
-    // Run the migration probe once and reuse its result for both the headline
+  async balance(
+    avatar: Address,
+    options?: { includeMigratable?: boolean },
+  ): Promise<GroupCrcBalance> {
+    const includeMigratable = options?.includeMigratable ?? true;
+
+    // One wall-clock reference for every demurrage conversion in this call, so
+    // the held figures and the migration estimate are normalized against the
+    // same instant. `CirclesConverter` otherwise samples `Date.now()` per call,
+    // which would let the parallel reads below drift apart by a few wei.
+    const nowUnixSeconds = BigInt(Math.floor(Date.now() / 1000));
+
+    // Run the migration probe once and reuse its result for both the
     // `migratable` figure AND the per-token personal breakdown — the path's
     // outgoing edges (the flow this migration would spend) are exactly what we
     // subtract from the held personal balances. "No path" is a normal empty
-    // state, not an error: fall back to an empty path.
-    const [bal, path, personalBalances] = await Promise.all([
+    // state, not an error: fall back to an empty path. When the caller opts out
+    // of migratable we skip the pathfinder call altogether (no round-trip) and
+    // use an empty path, so every figure collapses to its held (stable) form.
+    const emptyPath: PathfindingResult = { maxFlow: 0n, transfers: [] };
+    // Tag each fallible read with its outcome so a swallowed RPC failure is
+    // distinguishable from a genuine zero — `findPath`/`getTokenBalances` THROW
+    // on transport/server errors (a true "no path"/"no balance" is a normal
+    // non-error result), so a bare catch would otherwise mask an outage as a real
+    // zero. Surfaced via `migratableProbe` / `personalProbe`.
+    const probePromise: Promise<{
+      path: PathfindingResult;
+      probe: "ok" | "skipped" | "failed";
+    }> = includeMigratable
+      ? this.migrationPath({ avatar, maxEdges: DEFAULT_MAX_EDGES })
+          .then((p) => ({ path: p, probe: "ok" as const }))
+          .catch(() => ({ path: emptyPath, probe: "failed" as const }))
+      : Promise.resolve({ path: emptyPath, probe: "skipped" as const });
+
+    const [bal, probeResult, personalRead] = await Promise.all([
       this.balanceBreakdown(avatar),
-      this.migrationPath({ avatar, maxEdges: DEFAULT_MAX_EDGES }).catch(
-        (): PathfindingResult => ({ maxFlow: 0n, transfers: [] }),
-      ),
+      probePromise,
       new CirclesRpc(this.config.circlesConfig.circlesRpcUrl).balance
         .getTokenBalances(avatar)
-        .catch((): TokenBalance[] => []),
+        .then((b) => ({ balances: b, probe: "ok" as const }))
+        .catch(() => ({ balances: [] as TokenBalance[], probe: "failed" as const })),
     ]);
+    const path = probeResult.path;
+    const migratableProbe = probeResult.probe;
+    const personalBalances = personalRead.balances;
+    const personalProbe = personalRead.probe;
 
     // inflationary balance is in inflationary units — convert down to demurraged.
     const inflationaryErc20 = CirclesConverter.attoStaticCirclesToAttoCircles(
       bal.inflationaryWrapper,
+      nowUnixSeconds,
     );
     const scoreGroupHeldTotal =
       bal.erc1155 + bal.demurrageWrapper + inflationaryErc20;
@@ -597,9 +804,19 @@ export class PermissionlessGroup {
       avatar,
       personalBalances,
       path.transfers,
+      nowUnixSeconds,
     );
-    // Each entry's `total` is already the demurraged per-token sum.
+    // `total` is the post-migration estimate; `heldTotal` is the raw held figure.
     const personalTotal = personalBreakdown.reduce((sum, p) => sum + p.total, 0n);
+    const personalHeldTotal = personalBreakdown.reduce(
+      (sum, p) => sum + p.heldTotal,
+      0n,
+    );
+
+    // The migratable max-flow is computed at a specific indexer block; surface it
+    // so callers know which block the live estimate reflects (bigint, normalized
+    // at the RPC boundary).
+    const migratableAtBlock = path.graphBlock;
 
     return {
       scoreGroupBreakdown: {
@@ -610,8 +827,12 @@ export class PermissionlessGroup {
       scoreGroupHeldTotal,
       scoreGroupMigratable: path.maxFlow,
       scoreGroupTotal: scoreGroupHeldTotal + path.maxFlow,
+      ...(migratableAtBlock !== undefined ? { migratableAtBlock } : {}),
+      migratableProbe,
       personalBreakdown,
       personalTotal,
+      personalHeldTotal,
+      personalProbe,
     };
   }
 
@@ -629,15 +850,22 @@ export class PermissionlessGroup {
    *     (both are demurraged atto-CRC, same unit as the row).
    *   - inflationary-ERC20 rows: the row balance is in static units, so convert
    *     the edge's demurraged `value` to static before subtracting.
-   * Each form is clamped at 0 (the pathfinder figure and the indexer snapshot
-   * can disagree at the margin), and a token is emitted only if some form
-   * remains. Circles v1 balances (`version === 1`) are skipped — they're not
-   * migratable into a v2 score group.
+   * Each transferable form is clamped at 0 (the pathfinder figure and the
+   * indexer snapshot can disagree at the margin). Every entry also carries the
+   * raw held amount per form (before the subtraction) so the caller can read a
+   * stable `heldTotal` alongside the live `total`. A token is emitted whenever
+   * the avatar holds any of it (`heldTotal > 0`), even if the migration would
+   * spend all of it. Circles v1 balances (`version === 1`) are skipped — they're
+   * not migratable into a v2 score group.
+   *
+   * @param nowUnixSeconds - shared timestamp for the demurrage rollup so every
+   *   entry is normalized to the same instant.
    */
   private buildPersonalBreakdown(
     avatar: Address,
     held: TokenBalance[],
     transfers: TransferStep[],
+    nowUnixSeconds: bigint,
   ): PersonalTokenBalance[] {
     const group = this.config.groupAddress;
 
@@ -650,8 +878,15 @@ export class PermissionlessGroup {
       outgoingByToken.set(key, (outgoingByToken.get(key) ?? 0n) + BigInt(t.value));
     }
 
-    // Accumulate transferable amounts per issuer, bucketed by form.
-    const byOwner = new Map<string, PersonalTokenBalance>();
+    // Accumulate per issuer, bucketed by form. We track BOTH the raw held amount
+    // (`held*`, stable) and the amount left after subtracting the migration's
+    // outgoing flow (the public per-form fields, a live estimate).
+    type Acc = PersonalTokenBalance & {
+      heldErc1155: bigint;
+      heldDemurrageErc20: bigint;
+      heldInflationaryErc20: bigint;
+    };
+    const byOwner = new Map<string, Acc>();
     for (const row of held) {
       // Personal CRC means Circles v2 only. v1 tokens (`version === 1`) live in
       // the old Hub, can't be migrated into a v2 score group, and aren't
@@ -672,45 +907,70 @@ export class PermissionlessGroup {
           demurrageErc20: 0n,
           inflationaryErc20: 0n,
           total: 0n,
-        } satisfies PersonalTokenBalance);
+          heldTotal: 0n,
+          heldErc1155: 0n,
+          heldDemurrageErc20: 0n,
+          heldInflationaryErc20: 0n,
+        } satisfies Acc);
 
       const outgoing = outgoingByToken.get(row.tokenAddress.toLowerCase()) ?? 0n;
 
       if (row.isInflationary) {
         // Row balance is static; the outgoing edge value is demurraged.
-        const outgoingStatic =
-          CirclesConverter.attoCirclesToAttoStaticCircles(outgoing);
+        const outgoingStatic = CirclesConverter.attoCirclesToAttoStaticCircles(
+          outgoing,
+          nowUnixSeconds,
+        );
+        entry.heldInflationaryErc20 += row.staticAttoCircles;
         entry.inflationaryErc20 += clampSub(row.staticAttoCircles, outgoingStatic);
       } else if (row.isErc20) {
+        entry.heldDemurrageErc20 += row.attoCircles;
         entry.demurrageErc20 += clampSub(row.attoCircles, outgoing);
       } else {
+        entry.heldErc1155 += row.attoCircles;
         entry.erc1155 += clampSub(row.attoCircles, outgoing);
       }
 
       byOwner.set(ownerKey, entry);
     }
 
-    // Roll up each token's forms into a single demurraged `total` (the
-    // inflationary form is static, so convert it down before adding).
+    // Roll up each token's forms into demurraged totals (the inflationary form is
+    // static, so convert it down before adding). `total` is post-migration (a
+    // live estimate); `heldTotal` is the raw held figure (stable). Emit any token
+    // the avatar holds, even if the migration would spend all of it.
     return Array.from(byOwner.values())
-      .map((e) => ({
-        ...e,
-        total:
-          e.erc1155 +
-          e.demurrageErc20 +
-          CirclesConverter.attoStaticCirclesToAttoCircles(e.inflationaryErc20),
-      }))
-      .filter(
-        (e) => e.erc1155 > 0n || e.demurrageErc20 > 0n || e.inflationaryErc20 > 0n,
-      );
+      .map(
+        (e) =>
+          ({
+            tokenOwner: e.tokenOwner,
+            erc1155: e.erc1155,
+            demurrageErc20: e.demurrageErc20,
+            inflationaryErc20: e.inflationaryErc20,
+            total:
+              e.erc1155 +
+              e.demurrageErc20 +
+              CirclesConverter.attoStaticCirclesToAttoCircles(
+                e.inflationaryErc20,
+                nowUnixSeconds,
+              ),
+            heldTotal:
+              e.heldErc1155 +
+              e.heldDemurrageErc20 +
+              CirclesConverter.attoStaticCirclesToAttoCircles(
+                e.heldInflationaryErc20,
+                nowUnixSeconds,
+              ),
+          }) satisfies PersonalTokenBalance,
+      )
+      .filter((e) => e.heldTotal > 0n);
   }
 
   /**
    * Shared pathfinder lookup behind {@link migration} and
    * {@link migratableAmount}: routes `avatar`'s CRC into the SinkWrapper with
    * the migration constraints (destination = score group only, never sourcing
-   * the score group token, edge cap defaulting to 100). Validates params and
-   * throws if no path is found.
+   * the score group token, `maxEdges` defaulting to {@link DEFAULT_MAX_EDGES}).
+   * Validates params and throws on invalid input.
    */
   private async migrationPath(
     params: MigrationParams,
@@ -754,9 +1014,9 @@ export class PermissionlessGroup {
       // The migration must arrive at the sink as the ScoreGroup's CRC.
       toTokens: [scoreGroup],
       ...(params.fromTokens?.length ? { fromTokens: params.fromTokens } : {}),
-      // `maxEdges` is forwarded straight to the pathfinder's `maxTransfers`,
-      // which caps the number of flow edges it returns. Default to 40 so every
-      // migration probe asks for the same generous cap unless overridden.
+      // `maxEdges` is forwarded straight to the pathfinder's `maxTransfers` — it
+      // steers the search, not a hard cap on the returned edges. Default to 40 so
+      // every migration probe asks for the same generous value unless overridden.
       maxTransfers: params.maxEdges ?? DEFAULT_MAX_EDGES,
       useWrappedBalances: true,
     });

--- a/packages/permissionless-groups/src/tests/migrateWithRetry.test.ts
+++ b/packages/permissionless-groups/src/tests/migrateWithRetry.test.ts
@@ -1,0 +1,297 @@
+import { describe, test, expect } from 'bun:test';
+import type { Address, TransactionRequest } from '@aboutcircles/sdk-types';
+import { PermissionlessGroup } from '../PermissionlessGroup.js';
+import type {
+  MigrationParams,
+  MigrationResult,
+  MigrationAttempt,
+  MigrationRetryResult,
+} from '../types.js';
+
+const GROUP = '0x93eD5A96347927ff6fF6b790F8Cf5258240c321f' as Address;
+const HUB = '0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8' as Address;
+const LIFT = '0x5F99a795dD2743C36D63511f0D4bc667e6d3cDB5' as Address;
+const AVATAR = '0x1111111111111111111111111111111111111111' as Address;
+
+function group(): PermissionlessGroup {
+  return new PermissionlessGroup({
+    groupAddress: GROUP,
+    hubAddress: HUB,
+    liftERC20Address: LIFT,
+    backendBaseUrl: 'http://backend.invalid',
+    rpcUrl: 'http://rpc.invalid',
+    circlesConfig: {} as never,
+  });
+}
+
+const TX: TransactionRequest = { to: HUB, data: '0x', value: 0n };
+
+/** Stub `migration()` so the retry logic runs with no network. Returns the
+ *  sequence of `maxEdges` it was called with. */
+function stubMigration(
+  g: PermissionlessGroup,
+  impl: (p: MigrationParams) => MigrationResult | Promise<MigrationResult>,
+): number[] {
+  const seenEdges: number[] = [];
+  (g as unknown as {
+    migration: (p: MigrationParams) => Promise<MigrationResult>;
+  }).migration = async (p: MigrationParams) => {
+    seenEdges.push(p.maxEdges ?? -1);
+    return impl(p);
+  };
+  return seenEdges;
+}
+
+function expectSuccess<T>(
+  r: MigrationRetryResult<T>,
+): Extract<MigrationRetryResult<T>, { success: true }> {
+  expect(r.success).toBe(true);
+  if (!r.success) throw new Error('expected success');
+  return r;
+}
+function expectFailure<T>(
+  r: MigrationRetryResult<T>,
+): Extract<MigrationRetryResult<T>, { success: false }> {
+  expect(r.success).toBe(false);
+  if (r.success) throw new Error('expected failure');
+  return r;
+}
+
+describe('migrateWithRetry — happy path & hop reduction', () => {
+  test('re-queries and shrinks the edge cap on each revert, then succeeds', async () => {
+    const g = group();
+    const caps = stubMigration(g, (p) => ({
+      txs: [TX],
+      amount: 100n,
+      edges: p.maxEdges ?? 0,
+    }));
+
+    let submitCalls = 0;
+    const res = await g.migrateWithRetry(
+      { avatar: AVATAR },
+      async () => {
+        submitCalls += 1;
+        if (submitCalls < 3) throw new Error('operateFlowMatrix reverted: ERC1155InsufficientBalance');
+        return 'TXHASH';
+      },
+      { startEdges: 40, reductionFactor: 0.5, minEdges: 5 },
+    );
+
+    const ok = expectSuccess(res);
+    expect(ok.result).toBe('TXHASH');
+    expect(ok.amount).toBe(100n);
+    expect(caps).toEqual([40, 20, 10]);
+    expect(ok.attempts).toHaveLength(3);
+    expect(ok.attempts[0].error).toContain('ERC1155InsufficientBalance');
+    expect(ok.attempts[2].error).toBeUndefined();
+  });
+
+  test('next cap is keyed on the route’s ACTUAL edge count, not the requested cap', async () => {
+    const g = group();
+    // Requested cap is 40, but the built route only uses 12 edges.
+    const caps = stubMigration(g, () => ({ txs: [TX], amount: 1n, edges: 12 }));
+
+    let submitCalls = 0;
+    await g.migrateWithRetry(
+      { avatar: AVATAR },
+      async () => {
+        submitCalls += 1;
+        if (submitCalls < 2) throw new Error('revert');
+        return 'OK';
+      },
+      { startEdges: 40, reductionFactor: 0.5, minEdges: 1 },
+    );
+
+    // 1st cap 40 (built edges 12) → fail → next = floor(12 * 0.5) = 6, NOT 20.
+    expect(caps).toEqual([40, 6]);
+  });
+
+  test('the submit callback receives accurate attempt info; attempts log carries amount/edges/maxEdges', async () => {
+    const g = group();
+    stubMigration(g, (p) => ({ txs: [TX], amount: 77n, edges: (p.maxEdges ?? 0) + 1 }));
+
+    const seen: MigrationAttempt[] = [];
+    const res = await g.migrateWithRetry(
+      { avatar: AVATAR },
+      async (_txs, attempt) => {
+        seen.push(attempt);
+        if (attempt.attempt < 2) throw new Error('revert');
+        return 'OK';
+      },
+      { startEdges: 30, reductionFactor: 0.5, minEdges: 1 },
+    );
+
+    const ok = expectSuccess(res);
+    expect(seen[0]).toEqual({ attempt: 1, maxEdges: 30, amount: 77n, edges: 31 });
+    expect(seen[1].attempt).toBe(2);
+    expect(seen[1].maxEdges).toBe(15); // floor(31 * 0.5)
+    expect(ok.attempts[1]).toMatchObject({ attempt: 2, maxEdges: 15, amount: 77n, edges: 16 });
+  });
+});
+
+describe('migrateWithRetry — failure outcomes', () => {
+  test('stops immediately (no submit) when nothing is migratable → reason "empty"', async () => {
+    const g = group();
+    const caps = stubMigration(g, () => ({ txs: [], amount: 0n, edges: 0 }));
+
+    let submitCalls = 0;
+    const res = await g.migrateWithRetry({ avatar: AVATAR }, async () => {
+      submitCalls += 1;
+      return 'X';
+    });
+
+    const fail = expectFailure(res);
+    expect(fail.reason).toBe('empty');
+    expect(submitCalls).toBe(0);
+    expect(caps).toHaveLength(1);
+    expect(fail.attempts[0].error).toContain('empty batch');
+  });
+
+  test('exhausting all retries → reason "exhausted" with the full log', async () => {
+    const g = group();
+    const caps = stubMigration(g, (p) => ({ txs: [TX], amount: 50n, edges: p.maxEdges ?? 0 }));
+
+    const res = await g.migrateWithRetry(
+      { avatar: AVATAR },
+      async () => {
+        throw new Error('revert');
+      },
+      { maxAttempts: 3, startEdges: 30, minEdges: 5, reductionFactor: 0.5 },
+    );
+
+    const fail = expectFailure(res);
+    expect(fail.reason).toBe('exhausted');
+    expect(fail.amount).toBe(0n);
+    expect(fail.attempts).toHaveLength(3);
+    expect(fail.attempts.every((a) => a.error)).toBe(true);
+    expect(caps).toEqual([30, 15, 7]);
+  });
+
+  test('edge cap never drops below minEdges', async () => {
+    const g = group();
+    const caps = stubMigration(g, (p) => ({ txs: [TX], amount: 1n, edges: p.maxEdges ?? 0 }));
+
+    await g.migrateWithRetry(
+      { avatar: AVATAR },
+      async () => {
+        throw new Error('revert');
+      },
+      { maxAttempts: 5, startEdges: 8, minEdges: 5, reductionFactor: 0.5 },
+    );
+
+    expect(caps[0]).toBe(8);
+    expect(caps.slice(1).every((c) => c === 5)).toBe(true);
+  });
+});
+
+describe('migrateWithRetry — error classification & build errors', () => {
+  test('a non-retryable submit error (user rejection) is rethrown, not retried', async () => {
+    const g = group();
+    const caps = stubMigration(g, (p) => ({ txs: [TX], amount: 1n, edges: p.maxEdges ?? 0 }));
+
+    let submitCalls = 0;
+    await expect(
+      g.migrateWithRetry({ avatar: AVATAR }, async () => {
+        submitCalls += 1;
+        throw new Error('MetaMask Tx Signature: User rejected the request.');
+      }),
+    ).rejects.toThrow('User rejected');
+
+    expect(submitCalls).toBe(1); // no re-prompt with a smaller migration
+    expect(caps).toHaveLength(1);
+  });
+
+  test('a non-Error throw from submit (programmer bug) is fatal, not swallowed', async () => {
+    const g = group();
+    stubMigration(g, (p) => ({ txs: [TX], amount: 1n, edges: p.maxEdges ?? 0 }));
+
+    await expect(
+      g.migrateWithRetry({ avatar: AVATAR }, async () => {
+        // e.g. a TypeError surfaced as a thrown non-Error
+        throw 'boom';
+      }),
+    ).rejects.toBe('boom');
+  });
+
+  test('custom isRetryable can force a retry on an otherwise-fatal-looking error', async () => {
+    const g = group();
+    const caps = stubMigration(g, (p) => ({ txs: [TX], amount: 1n, edges: p.maxEdges ?? 0 }));
+
+    let submitCalls = 0;
+    const res = await g.migrateWithRetry(
+      { avatar: AVATAR },
+      async () => {
+        submitCalls += 1;
+        if (submitCalls < 2) throw new Error('user rejected'); // normally fatal
+        return 'OK';
+      },
+      { isRetryable: () => true, startEdges: 10, minEdges: 1, reductionFactor: 0.5 },
+    );
+
+    expectSuccess(res);
+    expect(submitCalls).toBe(2);
+    expect(caps).toEqual([10, 5]);
+  });
+
+  test('a build/pathfinder error is logged and retried (not thrown), preserving the attempt log', async () => {
+    const g = group();
+    let calls = 0;
+    const caps = stubMigration(g, (p) => {
+      calls += 1;
+      if (calls === 1) throw new Error('circlesV2_findPath: connection failed');
+      return { txs: [TX], amount: 9n, edges: p.maxEdges ?? 0 };
+    });
+
+    const res = await g.migrateWithRetry(
+      { avatar: AVATAR },
+      async () => 'OK',
+      { startEdges: 20, minEdges: 1, reductionFactor: 0.5 },
+    );
+
+    const ok = expectSuccess(res);
+    expect(ok.result).toBe('OK');
+    expect(caps).toEqual([20, 10]); // build failed at 20 → retried at 10
+    expect(ok.attempts).toHaveLength(2);
+    expect(ok.attempts[0].error).toContain('connection failed');
+  });
+});
+
+describe('migrateWithRetry — defaults & option validation', () => {
+  test('defaults: startEdges falls back to params.maxEdges, reduction 0.6', async () => {
+    const g = group();
+    const caps = stubMigration(g, (p) => ({ txs: [TX], amount: 1n, edges: p.maxEdges ?? 0 }));
+
+    await g.migrateWithRetry({ avatar: AVATAR, maxEdges: 25 }, async () => {
+      throw new Error('revert');
+    });
+
+    expect(caps[0]).toBe(25); // params.maxEdges
+    expect(caps[1]).toBe(15); // floor(25 * 0.6)
+  });
+
+  test('defaults: bare params → startEdges 40 (DEFAULT_MAX_EDGES)', async () => {
+    const g = group();
+    const caps = stubMigration(g, (p) => ({ txs: [TX], amount: 1n, edges: p.maxEdges ?? 0 }));
+
+    await g.migrateWithRetry({ avatar: AVATAR }, async () => {
+      throw new Error('revert');
+    });
+
+    expect(caps[0]).toBe(40);
+    expect(caps[1]).toBe(24); // floor(40 * 0.6)
+  });
+
+  test('rejects nonsensical options', async () => {
+    const g = group();
+    stubMigration(g, (p) => ({ txs: [TX], amount: 1n, edges: p.maxEdges ?? 0 }));
+    const submit = async () => 'X';
+
+    await expect(g.migrateWithRetry({ avatar: AVATAR }, submit, { maxAttempts: 0 })).rejects.toThrow();
+    await expect(g.migrateWithRetry({ avatar: AVATAR }, submit, { reductionFactor: 1 })).rejects.toThrow();
+    await expect(g.migrateWithRetry({ avatar: AVATAR }, submit, { reductionFactor: 0 })).rejects.toThrow();
+    await expect(g.migrateWithRetry({ avatar: AVATAR }, submit, { minEdges: 0 })).rejects.toThrow();
+    await expect(
+      g.migrateWithRetry({ avatar: AVATAR }, submit, { startEdges: 3, minEdges: 5 }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/permissionless-groups/src/tests/personalBreakdown.test.ts
+++ b/packages/permissionless-groups/src/tests/personalBreakdown.test.ts
@@ -1,13 +1,24 @@
 import { describe, test, expect } from 'bun:test';
-import type { Address, TokenBalance } from '@aboutcircles/sdk-types';
+import type { Address, TokenBalance, TransferStep } from '@aboutcircles/sdk-types';
+import { CirclesConverter } from '@aboutcircles/sdk-utils/circlesConverter';
 import { PermissionlessGroup } from '../PermissionlessGroup.js';
 
 const GROUP = '0x93eD5A96347927ff6fF6b790F8Cf5258240c321f' as Address;
 const HUB = '0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8' as Address;
 const LIFT = '0x5F99a795dD2743C36D63511f0D4bc667e6d3cDB5' as Address;
+const SINK = '0xD4cF9afd3aE777C24454b70dd28E32d1bd516F05' as Address;
 const AVATAR = '0x1111111111111111111111111111111111111111' as Address;
 const V2_HUMAN = '0xAaA0000000000000000000000000000000000001' as Address;
 const V1_HUMAN = '0xbBb0000000000000000000000000000000000002' as Address;
+// ERC20 wrapper contracts — deliberately != the issuer, to exercise the
+// `tokenAddress`-keyed outgoing subtraction.
+const DEMURRAGE_WRAPPER = '0xDDD0000000000000000000000000000000000010' as Address;
+const INFLATIONARY_WRAPPER = '0xEEE0000000000000000000000000000000000011' as Address;
+
+// Fixed reference instant — only matters for the inflationary (static↔demurraged)
+// conversion paths; ERC1155 / demurrage-ERC20 forms carry no conversion.
+const NOW = 1_700_000_000n;
+const ONE = 10n ** 18n;
 
 function group(): PermissionlessGroup {
   return new PermissionlessGroup({
@@ -20,35 +31,58 @@ function group(): PermissionlessGroup {
   });
 }
 
-/** Minimal ERC1155 TokenBalance row with an overridable version. */
-function row(owner: Address, version: number, atto: bigint): TokenBalance {
+/** Flexible TokenBalance fixture across all three forms. */
+function makeRow(opts: {
+  owner: Address;
+  tokenAddress?: Address;
+  version?: number;
+  isErc20?: boolean;
+  isInflationary?: boolean;
+  atto?: bigint; // demurraged (attoCircles) — used by ERC1155 / demurrage-ERC20
+  staticAtto?: bigint; // static (staticAttoCircles) — used by inflationary-ERC20
+}): TokenBalance {
+  const isErc20 = opts.isErc20 ?? false;
+  const isInflationary = opts.isInflationary ?? false;
+  const version = opts.version ?? 2;
   return {
-    tokenAddress: owner,
-    tokenId: owner,
-    tokenOwner: owner,
+    tokenAddress: opts.tokenAddress ?? opts.owner,
+    tokenId: opts.owner,
+    tokenOwner: opts.owner,
     tokenType: version === 1 ? 'CrcV1_Signup' : 'CrcV2_RegisterHuman',
     version,
-    attoCircles: atto,
+    attoCircles: opts.atto ?? 0n,
     circles: 0,
-    staticAttoCircles: atto,
+    staticAttoCircles: opts.staticAtto ?? opts.atto ?? 0n,
     staticCircles: 0,
     attoCrc: 0n,
     crc: 0,
-    isErc20: false,
-    isErc1155: true,
-    isWrapped: false,
-    isInflationary: false,
+    isErc20,
+    isErc1155: !isErc20,
+    isWrapped: isErc20,
+    isInflationary,
     isGroup: false,
   };
 }
 
-// `buildPersonalBreakdown` is private — exercise it directly; it's pure (no I/O).
+/** Convenience: a plain ERC1155 row (the common case). */
+function row(owner: Address, version: number, atto: bigint): TokenBalance {
+  return makeRow({ owner, version, atto });
+}
+
+/** A migration pathfinder edge spending `tokenOwner`'s token out of `from`.
+ *  Note: the edge's `tokenOwner` is keyed against the row's `tokenAddress`. */
+function spend(from: Address, tokenKey: Address, value: bigint): TransferStep {
+  return { from, to: SINK, tokenOwner: tokenKey, value };
+}
+
+type Entry = { tokenOwner: Address; total: bigint; heldTotal: bigint };
 type WithBreakdown = {
   buildPersonalBreakdown(
     avatar: Address,
     held: TokenBalance[],
-    transfers: never[],
-  ): { tokenOwner: Address; total: bigint }[];
+    transfers: TransferStep[],
+    nowUnixSeconds: bigint,
+  ): Entry[];
 };
 
 describe('buildPersonalBreakdown — v1 filtering', () => {
@@ -56,21 +90,154 @@ describe('buildPersonalBreakdown — v1 filtering', () => {
     const g = group() as unknown as WithBreakdown;
     const out = g.buildPersonalBreakdown(
       AVATAR,
-      [row(V2_HUMAN, 2, 5n * 10n ** 18n), row(V1_HUMAN, 1, 9n * 10n ** 18n)],
+      [row(V2_HUMAN, 2, 5n * ONE), row(V1_HUMAN, 1, 9n * ONE)],
       [],
+      NOW,
     );
     expect(out).toHaveLength(1);
     expect(out[0].tokenOwner).toBe(V2_HUMAN);
-    expect(out[0].total).toBe(5n * 10n ** 18n);
+    expect(out[0].total).toBe(5n * ONE);
+    expect(out[0].heldTotal).toBe(5n * ONE);
   });
 
   test('drops an avatar whose only holding is v1 (no phantom entry)', () => {
     const g = group() as unknown as WithBreakdown;
+    const out = g.buildPersonalBreakdown(AVATAR, [row(V1_HUMAN, 1, 100n * ONE)], [], NOW);
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe('buildPersonalBreakdown — held vs. live total (ERC1155)', () => {
+  test('heldTotal is the raw held; total subtracts the migration outflow', () => {
+    const g = group() as unknown as WithBreakdown;
     const out = g.buildPersonalBreakdown(
       AVATAR,
-      [row(V1_HUMAN, 1, 100n * 10n ** 18n)],
-      [],
+      [row(V2_HUMAN, 2, 5n * ONE)],
+      [spend(AVATAR, V2_HUMAN, 2n * ONE)],
+      NOW,
     );
-    expect(out).toHaveLength(0);
+    expect(out[0].heldTotal).toBe(5n * ONE);
+    expect(out[0].total).toBe(3n * ONE);
+  });
+
+  test('heldTotal is independent of the pathfinder result', () => {
+    const g = group() as unknown as WithBreakdown;
+    const held = [row(V2_HUMAN, 2, 5n * ONE)];
+    const noFlow = g.buildPersonalBreakdown(AVATAR, held, [], NOW);
+    const someFlow = g.buildPersonalBreakdown(AVATAR, held, [spend(AVATAR, V2_HUMAN, 4n * ONE)], NOW);
+    expect(noFlow[0].total).toBe(5n * ONE);
+    expect(someFlow[0].total).toBe(1n * ONE);
+    expect(noFlow[0].heldTotal).toBe(5n * ONE);
+    expect(someFlow[0].heldTotal).toBe(5n * ONE);
+  });
+
+  test('a token fully spent by the migration still appears (heldTotal > 0, total = 0)', () => {
+    const g = group() as unknown as WithBreakdown;
+    const out = g.buildPersonalBreakdown(
+      AVATAR,
+      [row(V2_HUMAN, 2, 5n * ONE)],
+      [spend(AVATAR, V2_HUMAN, 5n * ONE)],
+      NOW,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].heldTotal).toBe(5n * ONE);
+    expect(out[0].total).toBe(0n);
+  });
+});
+
+describe('buildPersonalBreakdown — inflationary ERC20 (demurrage conversion)', () => {
+  test('heldTotal converts static held DOWN to demurraged (and the conversion is non-identity)', () => {
+    const g = group() as unknown as WithBreakdown;
+    const heldStatic = 5n * ONE;
+    const out = g.buildPersonalBreakdown(
+      AVATAR,
+      [makeRow({ owner: V2_HUMAN, tokenAddress: INFLATIONARY_WRAPPER, isErc20: true, isInflationary: true, staticAtto: heldStatic })],
+      [],
+      NOW,
+    );
+    const expected = CirclesConverter.attoStaticCirclesToAttoCircles(heldStatic, NOW);
+    expect(out).toHaveLength(1);
+    expect(out[0].heldTotal).toBe(expected);
+    expect(out[0].total).toBe(expected); // no transfers
+    expect(expected).not.toBe(heldStatic); // guard: demurrage actually applied at NOW
+  });
+
+  test('total subtracts the outflow, converting the demurraged edge UP to static first', () => {
+    const g = group() as unknown as WithBreakdown;
+    const heldStatic = 5n * ONE;
+    const outDemurraged = 1n * ONE;
+    const out = g.buildPersonalBreakdown(
+      AVATAR,
+      [makeRow({ owner: V2_HUMAN, tokenAddress: INFLATIONARY_WRAPPER, isErc20: true, isInflationary: true, staticAtto: heldStatic })],
+      [spend(AVATAR, INFLATIONARY_WRAPPER, outDemurraged)], // edge keyed on the wrapper
+      NOW,
+    );
+    const outStatic = CirclesConverter.attoCirclesToAttoStaticCircles(outDemurraged, NOW);
+    const expectedTotal = CirclesConverter.attoStaticCirclesToAttoCircles(heldStatic - outStatic, NOW);
+    const expectedHeld = CirclesConverter.attoStaticCirclesToAttoCircles(heldStatic, NOW);
+    expect(out[0].heldTotal).toBe(expectedHeld);
+    expect(out[0].total).toBe(expectedTotal);
+    expect(out[0].total).toBeLessThan(out[0].heldTotal);
+  });
+});
+
+describe('buildPersonalBreakdown — demurrage ERC20 & tokenAddress keying', () => {
+  test('subtracts the outflow directly (no conversion), keyed on the wrapper tokenAddress', () => {
+    const g = group() as unknown as WithBreakdown;
+    const out = g.buildPersonalBreakdown(
+      AVATAR,
+      [makeRow({ owner: V2_HUMAN, tokenAddress: DEMURRAGE_WRAPPER, isErc20: true, atto: 5n * ONE })],
+      [spend(AVATAR, DEMURRAGE_WRAPPER, 2n * ONE)],
+      NOW,
+    );
+    expect(out[0].heldTotal).toBe(5n * ONE);
+    expect(out[0].total).toBe(3n * ONE);
+  });
+
+  test('an edge keyed on the issuer (not the wrapper) does NOT subtract from an ERC20 row', () => {
+    const g = group() as unknown as WithBreakdown;
+    const out = g.buildPersonalBreakdown(
+      AVATAR,
+      [makeRow({ owner: V2_HUMAN, tokenAddress: DEMURRAGE_WRAPPER, isErc20: true, atto: 5n * ONE })],
+      [spend(AVATAR, V2_HUMAN, 2n * ONE)], // wrong key: issuer, not the wrapper
+      NOW,
+    );
+    expect(out[0].total).toBe(5n * ONE); // untouched
+  });
+});
+
+describe('buildPersonalBreakdown — aggregation', () => {
+  test('one owner across all three forms rolls up into a single demurraged heldTotal', () => {
+    const g = group() as unknown as WithBreakdown;
+    const out = g.buildPersonalBreakdown(
+      AVATAR,
+      [
+        makeRow({ owner: V2_HUMAN, atto: 2n * ONE }), // ERC1155
+        makeRow({ owner: V2_HUMAN, tokenAddress: DEMURRAGE_WRAPPER, isErc20: true, atto: 3n * ONE }),
+        makeRow({ owner: V2_HUMAN, tokenAddress: INFLATIONARY_WRAPPER, isErc20: true, isInflationary: true, staticAtto: 4n * ONE }),
+      ],
+      [],
+      NOW,
+    );
+    expect(out).toHaveLength(1);
+    const expected = 2n * ONE + 3n * ONE + CirclesConverter.attoStaticCirclesToAttoCircles(4n * ONE, NOW);
+    expect(out[0].heldTotal).toBe(expected);
+    expect(out[0].total).toBe(expected);
+  });
+
+  test('personalHeldTotal (sum of heldTotal) is stable while personalTotal drifts', () => {
+    const g = group() as unknown as WithBreakdown;
+    const held = [
+      row(V2_HUMAN, 2, 5n * ONE),
+      row('0xCcc0000000000000000000000000000000000003' as Address, 2, 3n * ONE),
+    ];
+    const a = g.buildPersonalBreakdown(AVATAR, held, [], NOW);
+    const b = g.buildPersonalBreakdown(AVATAR, held, [spend(AVATAR, V2_HUMAN, 2n * ONE)], NOW);
+    const heldSum = (xs: Entry[]) => xs.reduce((s, x) => s + x.heldTotal, 0n);
+    const totalSum = (xs: Entry[]) => xs.reduce((s, x) => s + x.total, 0n);
+    expect(heldSum(a)).toBe(8n * ONE);
+    expect(heldSum(b)).toBe(8n * ONE);
+    expect(totalSum(a)).toBe(8n * ONE);
+    expect(totalSum(b)).toBe(6n * ONE);
   });
 });

--- a/packages/permissionless-groups/src/types.ts
+++ b/packages/permissionless-groups/src/types.ts
@@ -179,11 +179,23 @@ export interface PersonalTokenBalance {
   /** Transferable inflationary-wrapper ERC20 balance (inflationary/static): held − outgoing inflationary-ERC20 flow. */
   inflationaryErc20: bigint;
   /**
-   * Sum of this token's three forms, normalized to **demurraged** atto-CRC
-   * (`inflationaryErc20` converted down first) — the avatar's total transferable
-   * balance of this token in a single comparable unit.
+   * Sum of this token's three forms **after** the migration's outgoing flow is
+   * subtracted, normalized to **demurraged** atto-CRC (`inflationaryErc20`
+   * converted down first) — the transferable balance of this token left over
+   * once the migration in {@link GroupCrcBalance.scoreGroupMigratable} is spent.
+   * This is a **live estimate**: it moves with the pathfinder result (which
+   * tracks the indexer block). For a value that depends only on the avatar's own
+   * holdings, use {@link heldTotal}.
    */
   total: bigint;
+  /**
+   * Sum of this token's three forms **before** any migration subtraction,
+   * normalized to **demurraged** atto-CRC — the raw held balance of this token.
+   * Depends only on the avatar's own holdings, so it is **deterministic** for a
+   * given chain state (unlike {@link total}, which tracks the live pathfinder
+   * result).
+   */
+  heldTotal: bigint;
 }
 
 /**
@@ -203,7 +215,22 @@ export interface ScoreGroupBreakdown {
  * Result of `PermissionlessGroup.balance()` — the avatar's current score-group
  * CRC across all three forms PLUS the amount still migratable from legacy CRC,
  * all normalized to **demurraged** atto-CRC so the figures are summable;
- * alongside the avatar's transferable personal CRC.
+ * alongside the avatar's personal CRC.
+ *
+ * Two classes of figure are returned, and they behave differently:
+ *
+ *   - **Deterministic** (depend only on the avatar's own holdings for a given
+ *     chain state): {@link scoreGroupBreakdown}, {@link scoreGroupHeldTotal},
+ *     {@link personalBreakdown} `heldTotal`s, {@link personalHeldTotal}.
+ *   - **Live estimate** (computed from the migration pathfinder, a network
+ *     max-flow that tracks the indexer block — see {@link migratableAtBlock} —
+ *     and so changes between calls even when the avatar's holdings don't):
+ *     {@link scoreGroupMigratable}, {@link scoreGroupTotal}, the per-token
+ *     `total`s in {@link personalBreakdown}, and {@link personalTotal}.
+ *
+ * The migratable max-flow routes the avatar's CRC through the wider trust graph,
+ * so it is inherently unstable across blocks; prefer the deterministic figures
+ * for anything that must not change without a balance change.
  *
  * For the raw per-form breakdown + wrapper addresses, see
  * `PermissionlessGroup.balanceBreakdown()` ({@link BalanceResult}).
@@ -211,29 +238,78 @@ export interface ScoreGroupBreakdown {
 export interface GroupCrcBalance {
   /** Held score-group CRC per form (demurraged). See {@link ScoreGroupBreakdown}. */
   scoreGroupBreakdown: ScoreGroupBreakdown;
-  /** Sum of the three held forms (demurraged) — score-group CRC held right now. */
+  /**
+   * Sum of the three held forms (demurraged) — score-group CRC held right now.
+   * **Deterministic**: depends only on the avatar's own balances.
+   */
   scoreGroupHeldTotal: bigint;
-  /** Amount still migratable from legacy CRC (pathfinder, maxEdges {@link DEFAULT_MAX_EDGES}; demurraged). */
+  /**
+   * Amount still migratable from legacy CRC into the score group (migration
+   * pathfinder max-flow; demurraged). **Live estimate** — a network max-flow
+   * computed at {@link migratableAtBlock} that moves as the trust graph changes,
+   * independent of the avatar's own holdings.
+   */
   scoreGroupMigratable: bigint;
-  /** `scoreGroupHeldTotal + scoreGroupMigratable` (demurraged) — full reachable score-group CRC. */
+  /**
+   * `scoreGroupHeldTotal + scoreGroupMigratable` (demurraged) — full reachable
+   * score-group CRC. **Live estimate** (inherits the volatility of
+   * {@link scoreGroupMigratable}); use {@link scoreGroupHeldTotal} for a stable
+   * held-only figure.
+   */
   scoreGroupTotal: bigint;
   /**
+   * Indexer block the migration pathfinder computed {@link scoreGroupMigratable}
+   * (and the per-token `total`s in {@link personalBreakdown}) against, when the
+   * RPC reports it. `undefined` if the probe was skipped/failed, no path was
+   * found, or the RPC omitted the block — read {@link migratableProbe} to tell
+   * those apart.
+   */
+  migratableAtBlock?: bigint;
+  /**
+   * Outcome of the migration-pathfinder probe — disambiguates a `0n`
+   * {@link scoreGroupMigratable}:
+   *   - `'ok'`: the pathfinder ran; the migratable/total figures are live & valid.
+   *   - `'skipped'`: `includeMigratable: false` — the probe was not run; the live
+   *     figures equal their held counterparts by construction.
+   *   - `'failed'`: the pathfinder RPC errored; migratable fell back to `0n` and
+   *     `scoreGroupTotal`/`personalTotal` collapsed to the held figures. This is a
+   *     **fallback, not a real zero** — do not render it as "nothing to migrate".
+   */
+  migratableProbe: "ok" | "skipped" | "failed";
+  /**
    * Per-token personal-CRC breakdown: every personal CRC the avatar holds
-   * (human + non-group-token group/org CRC), with each form's amount reduced
-   * by the migration's outgoing flow that spent that form — i.e. what's left
-   * transferable after the migration this `balance()` accounts for in
-   * {@link scoreGroupMigratable}. One entry per issuing token; forms with a
-   * positive remaining balance only (fully-spent forms are clamped to 0 but the
-   * entry still appears if any form remains). See {@link PersonalTokenBalance}.
+   * (human + non-group-token group/org CRC). Each entry carries both a stable
+   * `heldTotal` (raw held) and a live `total` (held minus the migration's
+   * outgoing flow that spent that token). One entry per issuing token; an entry
+   * appears whenever the avatar holds any of that token (`heldTotal > 0`), even
+   * if the migration would spend all of it. Excludes the configured group's own
+   * token (counted as score-group CRC). See {@link PersonalTokenBalance}.
    */
   personalBreakdown: PersonalTokenBalance[];
   /**
-   * Sum of {@link personalBreakdown} across every token and form, normalized to
-   * **demurraged** atto-CRC (inflationary entries converted down first) — the
-   * avatar's total transferable personal CRC after the migration's outgoing
-   * flow is subtracted. Excludes the group's own token (counted as score-group CRC).
+   * Sum of the per-token `total`s in {@link personalBreakdown} (demurraged) —
+   * personal CRC left transferable after the migration's outgoing flow is
+   * subtracted. **Live estimate** (tracks the pathfinder); use
+   * {@link personalHeldTotal} for the stable held figure. Excludes the group's
+   * own token (counted as score-group CRC).
    */
   personalTotal: bigint;
+  /**
+   * Sum of the per-token `heldTotal`s in {@link personalBreakdown} (demurraged)
+   * — the avatar's total held personal CRC, before any migration subtraction.
+   * **Deterministic**: depends only on the avatar's own holdings. Excludes the
+   * group's own token (counted as score-group CRC).
+   */
+  personalHeldTotal: bigint;
+  /**
+   * Outcome of the `circles_getTokenBalances` read backing
+   * {@link personalBreakdown}:
+   *   - `'ok'`: balances were read; the personal figures are valid.
+   *   - `'failed'`: the read errored and was caught — `personalBreakdown` is empty
+   *     and `personalTotal`/`personalHeldTotal` are `0n` as a **fallback, not a
+   *     real zero**. Do not render it as "no personal CRC".
+   */
+  personalProbe: "ok" | "failed";
 }
 
 /**
@@ -269,10 +345,13 @@ export interface MigrationParams {
    */
   excludeFromTokens?: Address[];
   /**
-   * Cap the number of flow edges in the resulting `operateFlowMatrix`,
-   * forwarded directly to the pathfinder's `maxTransfers`. Lower values give
-   * a smaller, cheaper batch at a marginal cost to the migrated amount.
-   * Defaults to 40 when omitted.
+   * Forwarded directly to the pathfinder's `maxTransfers`. Influences how the
+   * pathfinder searches and splits the flow, but is **not** a hard cap on the
+   * number of edges returned — observed results carry slightly more transfer
+   * steps than this value, and raising it does not necessarily increase the
+   * routed amount. Higher values let the search fan out further (potentially a
+   * larger, costlier `operateFlowMatrix`); lower values steer it toward a
+   * smaller batch. Defaults to 40 when omitted.
    */
   maxEdges?: number;
   /**
@@ -300,7 +379,108 @@ export interface MigrationResult {
   txs: TransactionRequest[];
   /** Atto-CRC the pathfinder routed into the SinkWrapper. */
   amount: bigint;
+  /**
+   * Number of flow edges (transitive transfer hops) in the routed path. `0`
+   * when the batch is empty. More edges ⇒ a larger `operateFlowMatrix` and more
+   * exposure to intermediary balance changes between build and execution (each
+   * edge must still hold its baked amount on-chain or the tx reverts). Useful to
+   * gauge how fragile a migration is — see {@link MigrationRetryOptions}.
+   */
+  edges: number;
 }
+
+/**
+ * One attempt made by {@link PermissionlessGroup.migrateWithRetry}.
+ */
+export interface MigrationAttempt {
+  /** 1-based attempt number. */
+  attempt: number;
+  /** `maxEdges` cap the pathfinder was queried with for this attempt. */
+  maxEdges: number;
+  /** Atto-CRC the built batch would migrate (`0` if the batch was empty). */
+  amount: bigint;
+  /** Flow-edge count of the built batch. */
+  edges: number;
+}
+
+/**
+ * Options for {@link PermissionlessGroup.migrateWithRetry}.
+ *
+ * The migration path is a live network max-flow that goes stale within blocks
+ * (intermediary balances move), so a batch built even seconds early can revert.
+ * `migrateWithRetry` mitigates this by re-querying the pathfinder fresh on every
+ * attempt AND shrinking the edge cap after a failure — a shorter route touches
+ * fewer intermediaries and is less likely to be stale, at the cost of migrating
+ * a little less.
+ */
+export interface MigrationRetryOptions {
+  /** Maximum attempts (each one re-queries the pathfinder). Must be ≥ 1. Default 4. */
+  maxAttempts?: number;
+  /** Edge cap for the first attempt. Must be ≥ `minEdges`. Default `params.maxEdges` ?? 40. */
+  startEdges?: number;
+  /** Lower bound for the shrinking edge cap. Must be ≥ 1. Default 5. */
+  minEdges?: number;
+  /**
+   * After a failed attempt, the next edge cap is `floor(edgesUsed × factor)`
+   * (clamped to `minEdges`), where `edgesUsed` is the failed route's actual edge
+   * count. Must be in the open interval `(0, 1)`. Default 0.6.
+   */
+  reductionFactor?: number;
+  /**
+   * Classifies a thrown `submit` error: `true` ⇒ retryable revert (shrink hops &
+   * retry), `false` ⇒ fatal (rethrow immediately, abort the loop). Default:
+   * treat `Error`s as retryable EXCEPT user-rejection / cancellation messages,
+   * and treat non-`Error` throws (e.g. a bug in `submit`) as fatal. Override to
+   * match your runner's revert shape so a user cancel or a programmer error
+   * isn't re-prompted with a smaller migration.
+   */
+  isRetryable?: (error: unknown) => boolean;
+}
+
+/**
+ * A {@link MigrationAttempt} annotated with the failure message when that attempt
+ * failed. `error` is absent on the attempt that succeeded.
+ */
+export interface MigrationAttemptLog extends MigrationAttempt {
+  error?: string;
+}
+
+/**
+ * Result of {@link PermissionlessGroup.migrateWithRetry} — a discriminated union
+ * on `success`, so `result` narrows without a non-null assertion.
+ *
+ * The method **returns** (does not throw) for the two *normal* failure outcomes:
+ * `reason: 'empty'` (nothing migratable / only dust) and `reason: 'exhausted'`
+ * (every attempt's submit reverted). It **throws** only on a non-retryable
+ * `submit` error (e.g. a user rejection — see
+ * {@link MigrationRetryOptions.isRetryable}); pathfinder/build errors are treated
+ * as retryable and logged into `attempts`, not thrown.
+ *
+ * @typeParam T - the submit callback's return type (e.g. a tx hash / receipt).
+ */
+export type MigrationRetryResult<T> =
+  | {
+      success: true;
+      /** The successful submit's return value. */
+      result: T;
+      /** Atto-CRC migrated by the successful attempt. */
+      amount: bigint;
+      /** Every attempt in order; the last one succeeded. */
+      attempts: MigrationAttemptLog[];
+    }
+  | {
+      success: false;
+      /**
+       * Why it failed: `'empty'` = nothing to migrate (benign, like
+       * {@link migration} returning an empty batch); `'exhausted'` = real value
+       * but every attempt's submit reverted (worth surfacing/retrying later).
+       */
+      reason: "empty" | "exhausted";
+      /** Always `0n` — nothing was migrated. */
+      amount: bigint;
+      /** Every attempt in order, each annotated with its `error`. */
+      attempts: MigrationAttemptLog[];
+    };
 
 /**
  * A score-attested transaction batch: the txs to submit, the backend proof

--- a/packages/rpc/src/methods/pathfinder.ts
+++ b/packages/rpc/src/methods/pathfinder.ts
@@ -33,6 +33,13 @@ export class PathfinderMethods {
     );
 
     const parsed = parseStringsToBigInt(result) as unknown as PathfindingResult;
+    // `parseStringsToBigInt` converts numeric *strings* to bigint but leaves JSON
+    // *numbers* as-is, so `graphBlock` arrives as bigint | number depending on how
+    // the RPC serialized it. Normalize to bigint once here so the type can be a
+    // plain `bigint` and consumers don't each re-coerce.
+    if (parsed.graphBlock !== undefined) {
+      parsed.graphBlock = BigInt(parsed.graphBlock);
+    }
     return checksumAddresses(parsed);
   }
 

--- a/packages/types/src/pathfinding.ts
+++ b/packages/types/src/pathfinding.ts
@@ -56,6 +56,14 @@ export interface TransferStep {
 export interface PathfindingResult {
   maxFlow: bigint;
   transfers: TransferStep[];
+  /**
+   * Indexer block the pathfinder computed this result against, when the RPC
+   * reports it (normalized to `bigint` at the RPC boundary). `maxFlow` is a
+   * network max-flow over the trust graph at this block — it moves as the block
+   * advances even when the source avatar's own holdings don't, so it's only
+   * meaningful relative to this block.
+   */
+  graphBlock?: bigint;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds **deterministic held-balance figures** to `balance()` and a **resilient migration submit helper**. The migration pathfinder returns a network max-flow that moves block-to-block as the trust graph changes, so any figure derived from it is inherently unstable. This change gives callers stable, holdings-only numbers (independent of the pathfinder) and hardens migration execution against that same staleness. All changes are additive / non-breaking.

## What changed

### `balance()`
- **`personalHeldTotal`** + per-token **`heldTotal`** — raw held personal CRC, *before* the migration-outflow subtraction; deterministic for a given chain state.
- **`{ includeMigratable: false }`** option — skips the pathfinder probe entirely and returns held-only figures (faster, fully deterministic; `scoreGroupTotal === scoreGroupHeldTotal`).
- **`migratableAtBlock`**, plus **`migratableProbe`** (`ok|skipped|failed`) and **`personalProbe`** (`ok|failed`) — surface which block the live estimate was computed at, and whether each fallible read succeeded, so a swallowed RPC failure is distinguishable from a genuine zero.
- Single demurrage timestamp threaded through all conversions in the call.
- Field docs now label each figure **deterministic** vs **live estimate**.

### Migration
- **`MigrationResult.edges`** — flow-edge count (path complexity / fragility gauge).
- **`migrateWithRetry(params, submit, options)`** — re-queries the pathfinder fresh on each attempt and shrinks the edge cap on a *retryable* revert (shorter, less-stale route); **rethrows non-retryable** submit errors (e.g. user rejection) instead of re-prompting; returns a **discriminated** result with `reason: 'empty' | 'exhausted'`; validates options.

### Misc
- Normalize `PathfindingResult.graphBlock` to `bigint` at the RPC boundary.
- Correct `maxEdges` docs (forwarded to the pathfinder's `maxTransfers`; not a hard cap on the number of returned edges).

## Test plan
- [x] `bun run build` (typecheck) passes
- [x] `bun test` in `packages/permissionless-groups` passes (70 tests)
- [x] `personalHeldTotal` / `scoreGroupHeldTotal` are stable across repeated `balance()` calls while `scoreGroupMigratable` may vary
- [ ] `balance(avatar, { includeMigratable: false })` returns `scoreGroupTotal === scoreGroupHeldTotal` and issues no pathfinder call
- [ ] `migrateWithRetry` retries with a shrinking edge cap on a retryable revert, rethrows a user-rejection error, and reports `reason: 'exhausted'` when all attempts revert
