### PR TITLE
build(release): add prerelease (RC) publishing to the next dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version_type:
-        description: 'Version bump type'
+        description: 'Version bump type (prerelease = RC published to the `next` dist-tag)'
         required: true
         default: 'patch'
         type: choice
@@ -12,6 +12,7 @@ on:
           - patch
           - minor
           - major
+          - prerelease
 
 jobs:
   release:
@@ -39,9 +40,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Bump versions
-        run: |
-          VERSION_TYPE="${{ github.event.inputs.version_type }}"
-          bun run version:$VERSION_TYPE
+        env:
+          VERSION_TYPE: ${{ github.event.inputs.version_type }}
+        run: bun run version:"$VERSION_TYPE"
 
       - name: Setup Node.js for npm
         uses: actions/setup-node@v4

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,63 @@
+# Releasing
+
+All packages are versioned in **lockstep** (one version across the whole
+monorepo) and published to npm under the `@aboutcircles/*` scope with
+provenance. Releases are cut by the **Release** GitHub Actions workflow
+(`.github/workflows/release.yml`), triggered manually via **workflow_dispatch**
+— the PR itself never bumps versions.
+
+## Stable release
+
+1. Actions → **Release** → **Run workflow**.
+2. Pick `version_type`: `patch` | `minor` | `major`.
+3. The workflow builds, bumps every package to the new version, commits
+   `chore: bump version to X.Y.Z`, tags `vX.Y.Z`, publishes all packages to the
+   default **`latest`** dist-tag, and pushes the commit + tag.
+
+Consumers get it via `npm i @aboutcircles/sdk` as usual.
+
+## Release candidate (RC) for internal testing
+
+1. Actions → **Release** → **Run workflow**, **on the PR/release branch**.
+2. Pick `version_type`: `prerelease`.
+3. Produces `X.Y.(Z+1)-rc.0` (or bumps `-rc.n → -rc.(n+1)` if already on an RC of
+   the same series) and publishes to the **`next`** dist-tag — so `latest` (the
+   last stable) is untouched.
+
+Install the RC:
+
+```bash
+npm i @aboutcircles/sdk@next        # newest RC on the next tag
+npm i @aboutcircles/sdk@0.1.58-rc.0 # or pin an exact RC
+```
+
+**Why internal deps still line up:** the packages pin each other as `"*"`, which
+npm resolves *excluding* prereleases — so a naive RC umbrella would pull the last
+*stable* sub-packages. `scripts/publish.ts` therefore rewrites each internal
+`@aboutcircles/*` dep to the **exact** RC version *in the published tarball only*
+(the on-disk change is reverted right after each publish; committed source keeps
+`"*"`). So `@aboutcircles/sdk@x-rc.n` transitively resolves the matching RC
+sub-packages.
+
+### Promote an RC to stable
+
+Dispatch **Release** with `version_type: patch` while on an `-rc.n` version — it
+**finalizes** to the release core (`0.1.58-rc.3 → 0.1.58`) rather than skipping a
+number, and publishes to `latest`.
+
+### ⚠️ Keep RC bumps off `main`
+
+The workflow commits the version bump + tag and `git push`es them to the ref it
+was dispatched from. An RC bump commit (`chore: bump version to X.Y.Z-rc.n`) and
+its tag land on that branch. **Do not merge that commit into `main`** — either
+dispatch RCs from a throwaway release branch, or drop/reset the bump commit
+before merging the PR, so `main` keeps a clean stable version line and `"*"`
+internal deps.
+
+## Local dry check
+
+The version math and dep-pinning are pure functions with unit tests:
+
+```bash
+bun test scripts/release-tooling.test.ts
+```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "version:patch": "bun scripts/bump-version.ts patch",
     "version:minor": "bun scripts/bump-version.ts minor",
     "version:major": "bun scripts/bump-version.ts major",
+    "version:prerelease": "bun scripts/bump-version.ts prerelease",
     "build": "tsc --build && bun run --filter '@aboutcircles/sdk-types' build && bun run --filter '@aboutcircles/sdk-abis' build && bun run --filter '@aboutcircles/sdk-utils' build && bun run --filter '@aboutcircles/sdk-profiles' build && bun run --filter '@aboutcircles/sdk-core' build && bun run --filter '@aboutcircles/sdk-rpc' build && bun run --filter '@aboutcircles/sdk-pathfinder' build && bun run --filter '@aboutcircles/sdk-transfers' build && bun run --filter '@aboutcircles/sdk-invitations' build && bun run --filter '@aboutcircles/sdk-permissionless-groups' build && bun run --filter '@aboutcircles/sdk' build && bun run --filter '@aboutcircles/sdk-runner' build && bun run --filter '@aboutcircles/miniapp-sdk' build",
     "build:miniapp-sdk": "bun run --filter '@aboutcircles/miniapp-sdk' build",
     "build:types": "bun run --filter '@aboutcircles/sdk-types' build",

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -2,10 +2,7 @@ import { $ } from "bun";
 import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
 
-const versionType = process.argv[2] || "patch";
-const packagesDir = resolve(__dirname, "../packages");
-
-// Read all package.json files
+// Packages kept in lockstep — every release sets all of these to one version.
 const packages = [
   "types",
   "abis",
@@ -22,43 +19,112 @@ const packages = [
   "miniapp-sdk",
 ];
 
-// Get current version from main SDK
-const sdkPackage = JSON.parse(
-  readFileSync(resolve(packagesDir, "sdk/package.json"), "utf-8")
-);
-const currentVersion = sdkPackage.version;
+export type VersionType = "major" | "minor" | "patch" | "prerelease";
 
-// Calculate new version
-const [major, minor, patch] = currentVersion.split(".").map(Number);
-let newVersion: string;
-
-switch (versionType) {
-  case "major":
-    newVersion = `${major + 1}.0.0`;
-    break;
-  case "minor":
-    newVersion = `${major}.${minor + 1}.0`;
-    break;
-  case "patch":
-  default:
-    newVersion = `${major}.${minor}.${patch + 1}`;
+export interface ParsedVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  /** Prerelease identifier, e.g. "rc" — undefined for a stable version. */
+  preid?: string;
+  /** Prerelease counter, e.g. 0 in `-rc.0` — undefined for a stable version. */
+  prenum?: number;
 }
 
-console.log(`Bumping version from ${currentVersion} to ${newVersion}`);
-
-// Update all package.json files
-for (const pkg of packages) {
-  const pkgPath = resolve(packagesDir, `${pkg}/package.json`);
-  const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8"));
-  pkgJson.version = newVersion;
-
-  writeFileSync(pkgPath, JSON.stringify(pkgJson, null, 2) + "\n");
-  console.log(`  ✓ Updated ${pkg}`);
+/**
+ * Parse `X.Y.Z` or `X.Y.Z-<preid>.<n>` (the only two shapes this repo emits).
+ * Throws on anything else so a malformed version fails loudly instead of
+ * silently producing `NaN` segments (the old `split(".").map(Number)` turned
+ * `0.1.58-rc.0` into `[0, 1, NaN, 0]`).
+ */
+export function parseVersion(version: string): ParsedVersion {
+  const m = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+)\.(\d+))?$/);
+  if (!m) {
+    throw new Error(
+      `Unparseable version "${version}" (expected X.Y.Z or X.Y.Z-preid.N)`,
+    );
+  }
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+    preid: m[4],
+    prenum: m[5] === undefined ? undefined : Number(m[5]),
+  };
 }
 
-// Commit changes
-await $`git add packages/*/package.json`;
-await $`git commit -m "chore: bump version to ${newVersion}"`;
-await $`git tag v${newVersion}`;
+/**
+ * Compute the next version. Mirrors `npm version <type>` semantics for the
+ * cases this repo uses:
+ *   - major / minor: bump that segment, drop any prerelease.
+ *   - patch: `X.Y.Z → X.Y.(Z+1)`, but *finalize* a prerelease in place
+ *     (`X.Y.Z-rc.n → X.Y.Z`) so an RC promotes to its own stable number
+ *     rather than skipping it.
+ *   - prerelease: from stable, open an RC for the next patch
+ *     (`X.Y.Z → X.Y.(Z+1)-rc.0`); from a matching-preid RC, bump the counter
+ *     (`…-rc.0 → …-rc.1`); from a different preid, restart at `.0`.
+ */
+export function nextVersion(
+  current: string,
+  type: VersionType,
+  preid = "rc",
+): string {
+  const { major, minor, patch, preid: curPreid, prenum } =
+    parseVersion(current);
+  const isPre = prenum !== undefined;
 
-console.log(`\n✓ Version bumped and tagged: v${newVersion}`);
+  switch (type) {
+    case "major":
+      return `${major + 1}.0.0`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "prerelease":
+      if (isPre && curPreid === preid) {
+        return `${major}.${minor}.${patch}-${preid}.${prenum! + 1}`;
+      }
+      if (isPre) {
+        // switching preid mid-cycle (rare) — restart the counter, keep the core
+        return `${major}.${minor}.${patch}-${preid}.0`;
+      }
+      return `${major}.${minor}.${patch + 1}-${preid}.0`;
+    case "patch":
+    default:
+      // Finalize a prerelease to its release core; otherwise a normal patch.
+      return isPre
+        ? `${major}.${minor}.${patch}`
+        : `${major}.${minor}.${patch + 1}`;
+  }
+}
+
+if (import.meta.main) {
+  const versionType = (process.argv[2] || "patch") as VersionType;
+  const preid = process.argv[3] || "rc";
+  const packagesDir = resolve(__dirname, "../packages");
+
+  // Get current version from the main SDK package.
+  const sdkPackage = JSON.parse(
+    readFileSync(resolve(packagesDir, "sdk/package.json"), "utf-8"),
+  );
+  const currentVersion: string = sdkPackage.version;
+  const newVersion = nextVersion(currentVersion, versionType, preid);
+
+  console.log(`Bumping version from ${currentVersion} to ${newVersion}`);
+
+  // Update all package.json files (versions only — internal `@aboutcircles/*`
+  // dep ranges stay `"*"`; prerelease pinning happens at publish time).
+  for (const pkg of packages) {
+    const pkgPath = resolve(packagesDir, `${pkg}/package.json`);
+    const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    pkgJson.version = newVersion;
+
+    writeFileSync(pkgPath, JSON.stringify(pkgJson, null, 2) + "\n");
+    console.log(`  ✓ Updated ${pkg}`);
+  }
+
+  // Commit changes
+  await $`git add packages/*/package.json`;
+  await $`git commit -m "chore: bump version to ${newVersion}"`;
+  await $`git tag v${newVersion}`;
+
+  console.log(`\n✓ Version bumped and tagged: v${newVersion}`);
+}

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,10 +1,25 @@
 #!/usr/bin/env bun
 /**
- * Cross-platform publishing script for all SDK packages
- * Publishes packages in dependency order with proper error handling
+ * Cross-platform publishing script for all SDK packages.
+ * Publishes packages in dependency order with proper error handling.
+ *
+ * Dist-tags:
+ *   - Stable versions (`X.Y.Z`) publish to the default `latest` tag.
+ *   - Prerelease versions (`X.Y.Z-rc.n`) publish to `next`, so `npm i <pkg>`
+ *     keeps resolving the last stable release.
+ *
+ * Prerelease internal-dep pinning:
+ *   This repo pins internal `@aboutcircles/*` deps as `"*"`, which npm resolves
+ *   *excluding* prereleases — so an umbrella `@aboutcircles/sdk@x-rc.n` would
+ *   otherwise pull the last *stable* sub-packages, not the matching RC ones.
+ *   For prerelease publishes we therefore rewrite each internal dep to the
+ *   exact prerelease version in the published tarball. The rewrite is applied
+ *   to the on-disk package.json only for the duration of the publish and
+ *   restored afterwards (verbatim), so the working tree / git stay clean.
  */
 import { $ } from 'bun';
 import { join } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
 
 // Define packages in dependency order
 const packages = [
@@ -25,6 +40,40 @@ const packages = [
 
 const packagesDir = join(process.cwd(), 'packages');
 
+const INTERNAL_SCOPE = '@aboutcircles/';
+const DEP_FIELDS = [
+  'dependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const;
+
+/** A version is a prerelease iff it carries a `-` suffix (e.g. `0.1.58-rc.0`). */
+export function isPrerelease(version: string): boolean {
+  return version.includes('-');
+}
+
+/**
+ * Return a copy of `pkgJson` with every internal `@aboutcircles/*` dependency
+ * range replaced by the exact `version`. Only the internal scope is touched;
+ * third-party ranges are left as-is. Used only for prerelease publishes.
+ */
+export function pinInternalDeps(
+  pkgJson: Record<string, any>,
+  version: string,
+): Record<string, any> {
+  const next = { ...pkgJson };
+  for (const field of DEP_FIELDS) {
+    const deps = pkgJson[field];
+    if (!deps) continue;
+    const pinned: Record<string, string> = { ...deps };
+    for (const name of Object.keys(pinned)) {
+      if (name.startsWith(INTERNAL_SCOPE)) pinned[name] = version;
+    }
+    next[field] = pinned;
+  }
+  return next;
+}
+
 function isAlreadyPublished(error: string): boolean {
   return error.includes('EPUBLISHCONFLICT') ||
     error.includes('cannot publish over previously published version');
@@ -39,25 +88,16 @@ async function isVersionPublished(pkgName: string, version: string): Promise<boo
   }
 }
 
-async function publishPackage(pkg: string): Promise<boolean> {
-  const pkgPath = join(packagesDir, pkg);
-
-  // Read package.json to get actual name and version
-  const pkgJsonPath = join(pkgPath, 'package.json');
-  const pkgJson = JSON.parse(await $`cat ${pkgJsonPath}`.text());
-  const pkgName = pkgJson.name ?? `@aboutcircles/sdk-${pkg}`;
-  const version = pkgJson.version;
-  console.log(`\n📦 Publishing ${pkgName}...`);
-
-  if (await isVersionPublished(pkgName, version)) {
-    console.log(`⚠️  ${pkgName}@${version} already published, skipping...`);
-    return true;
-  }
-
+async function runPublish(
+  pkgPath: string,
+  pkgName: string,
+  version: string,
+  distTag: string,
+): Promise<boolean> {
   try {
     // Use npm publish for provenance support (Bun doesn't support --provenance yet)
-    await $`cd ${pkgPath} && npm publish --access public --provenance 2>&1`;
-    console.log(`✅ Published ${pkgName}@${version}`);
+    await $`cd ${pkgPath} && npm publish --access public --provenance --tag ${distTag} 2>&1`;
+    console.log(`✅ Published ${pkgName}@${version} (tag: ${distTag})`);
     return true;
   } catch (error) {
     const errorStr = String(error);
@@ -70,8 +110,8 @@ async function publishPackage(pkg: string): Promise<boolean> {
     // If provenance fails, try without it
     console.log(`⚠️  Retrying without provenance...`);
     try {
-      await $`cd ${pkgPath} && npm publish --access public 2>&1`;
-      console.log(`✅ Published ${pkgName}@${version}`);
+      await $`cd ${pkgPath} && npm publish --access public --tag ${distTag} 2>&1`;
+      console.log(`✅ Published ${pkgName}@${version} (tag: ${distTag})`);
       return true;
     } catch (retryError) {
       const retryErrorStr = String(retryError);
@@ -83,6 +123,42 @@ async function publishPackage(pkg: string): Promise<boolean> {
       console.error(`Error: ${retryErrorStr}`);
       return false;
     }
+  }
+}
+
+async function publishPackage(pkg: string): Promise<boolean> {
+  const pkgPath = join(packagesDir, pkg);
+  const pkgJsonPath = join(pkgPath, 'package.json');
+
+  // Keep the exact original bytes so we can restore them verbatim.
+  const original = readFileSync(pkgJsonPath, 'utf-8');
+  const pkgJson = JSON.parse(original);
+  const pkgName = pkgJson.name ?? `@aboutcircles/sdk-${pkg}`;
+  const version = pkgJson.version;
+  const distTag = isPrerelease(version) ? 'next' : 'latest';
+  console.log(`\n📦 Publishing ${pkgName}@${version} (tag: ${distTag})...`);
+
+  if (await isVersionPublished(pkgName, version)) {
+    console.log(`⚠️  ${pkgName}@${version} already published, skipping...`);
+    return true;
+  }
+
+  // For prereleases, pin internal deps to the exact version in the published
+  // tarball (see file header). Restore the original file no matter what so the
+  // working tree never carries the pins.
+  let pinned = false;
+  if (isPrerelease(version)) {
+    writeFileSync(
+      pkgJsonPath,
+      JSON.stringify(pinInternalDeps(pkgJson, version), null, 2) + '\n',
+    );
+    pinned = true;
+  }
+
+  try {
+    return await runPublish(pkgPath, pkgName, version, distTag);
+  } finally {
+    if (pinned) writeFileSync(pkgJsonPath, original);
   }
 }
 
@@ -100,4 +176,6 @@ async function main() {
   console.log('\n🎉 All packages published successfully!');
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/scripts/release-tooling.test.ts
+++ b/scripts/release-tooling.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { nextVersion, parseVersion } from "./bump-version";
+import { isPrerelease, pinInternalDeps } from "./publish";
+
+describe("parseVersion", () => {
+  test("parses a stable version", () => {
+    expect(parseVersion("0.1.57")).toEqual({
+      major: 0,
+      minor: 1,
+      patch: 57,
+      preid: undefined,
+      prenum: undefined,
+    });
+  });
+
+  test("parses a prerelease version", () => {
+    expect(parseVersion("0.1.58-rc.3")).toEqual({
+      major: 0,
+      minor: 1,
+      patch: 58,
+      preid: "rc",
+      prenum: 3,
+    });
+  });
+
+  test("throws on a malformed version instead of yielding NaN", () => {
+    expect(() => parseVersion("0.1")).toThrow();
+    expect(() => parseVersion("0.1.x")).toThrow();
+    // The bug the regex guards against: the old split(".").map(Number) turned
+    // this into [0, 1, NaN, 0].
+    expect(() => parseVersion("0.1.58-rc")).toThrow();
+  });
+});
+
+describe("nextVersion — stable bumps", () => {
+  test("patch from stable", () => {
+    expect(nextVersion("0.1.57", "patch")).toBe("0.1.58");
+  });
+  test("minor from stable resets patch", () => {
+    expect(nextVersion("0.1.57", "minor")).toBe("0.2.0");
+  });
+  test("major from stable resets minor+patch", () => {
+    expect(nextVersion("0.1.57", "major")).toBe("1.0.0");
+  });
+  test("major/minor drop an in-flight prerelease", () => {
+    expect(nextVersion("0.1.58-rc.2", "minor")).toBe("0.2.0");
+    expect(nextVersion("0.1.58-rc.2", "major")).toBe("1.0.0");
+  });
+});
+
+describe("nextVersion — prerelease lifecycle", () => {
+  test("opens an RC for the next patch from a stable version", () => {
+    expect(nextVersion("0.1.57", "prerelease")).toBe("0.1.58-rc.0");
+  });
+  test("bumps the counter on a matching-preid RC", () => {
+    expect(nextVersion("0.1.58-rc.0", "prerelease")).toBe("0.1.58-rc.1");
+    expect(nextVersion("0.1.58-rc.9", "prerelease")).toBe("0.1.58-rc.10");
+  });
+  test("restarts the counter when the preid changes", () => {
+    expect(nextVersion("0.1.58-rc.4", "prerelease", "beta")).toBe(
+      "0.1.58-beta.0",
+    );
+  });
+  test("patch finalizes an RC to its release core (no version skipped)", () => {
+    expect(nextVersion("0.1.58-rc.0", "patch")).toBe("0.1.58");
+    expect(nextVersion("0.1.58-rc.5", "patch")).toBe("0.1.58");
+  });
+  test("full cycle: stable -> rc.0 -> rc.1 -> finalize", () => {
+    const rc0 = nextVersion("0.1.57", "prerelease");
+    const rc1 = nextVersion(rc0, "prerelease");
+    const stable = nextVersion(rc1, "patch");
+    expect([rc0, rc1, stable]).toEqual(["0.1.58-rc.0", "0.1.58-rc.1", "0.1.58"]);
+  });
+});
+
+describe("isPrerelease", () => {
+  test("true only when a prerelease suffix is present", () => {
+    expect(isPrerelease("0.1.58")).toBe(false);
+    expect(isPrerelease("0.1.58-rc.0")).toBe(true);
+  });
+});
+
+describe("pinInternalDeps", () => {
+  test("pins internal @aboutcircles/* deps to the exact version, leaves others", () => {
+    const pkg = {
+      name: "@aboutcircles/sdk",
+      version: "0.1.58-rc.0",
+      dependencies: {
+        "@aboutcircles/sdk-rpc": "*",
+        "@aboutcircles/sdk-types": "*",
+        viem: "^2.0.0",
+      },
+    };
+    const pinned = pinInternalDeps(pkg, "0.1.58-rc.0");
+    expect(pinned.dependencies).toEqual({
+      "@aboutcircles/sdk-rpc": "0.1.58-rc.0",
+      "@aboutcircles/sdk-types": "0.1.58-rc.0",
+      viem: "^2.0.0",
+    });
+  });
+
+  test("covers peer and optional dependency buckets", () => {
+    const pkg = {
+      peerDependencies: { "@aboutcircles/sdk-core": "*" },
+      optionalDependencies: { "@aboutcircles/sdk-utils": "*" },
+    };
+    const pinned = pinInternalDeps(pkg, "1.2.3-rc.1");
+    expect(pinned.peerDependencies["@aboutcircles/sdk-core"]).toBe("1.2.3-rc.1");
+    expect(pinned.optionalDependencies["@aboutcircles/sdk-utils"]).toBe(
+      "1.2.3-rc.1",
+    );
+  });
+
+  test("does not mutate the input object", () => {
+    const pkg = { dependencies: { "@aboutcircles/sdk-rpc": "*" } };
+    pinInternalDeps(pkg, "0.1.58-rc.0");
+    expect(pkg.dependencies["@aboutcircles/sdk-rpc"]).toBe("*");
+  });
+
+  test("is a no-op when there are no dependency fields", () => {
+    expect(pinInternalDeps({ name: "x" }, "0.1.58-rc.0")).toEqual({ name: "x" });
+  });
+});


### PR DESCRIPTION
## What

Adds a release-candidate path to the existing manual Release workflow, without changing stable-release behavior.

- **`prerelease` bump mode** (`scripts/bump-version.ts`): `X.Y.Z → X.Y.(Z+1)-rc.0`, counter bump on an existing RC (`-rc.0 → -rc.1`), and finalize-in-place on a `patch` bump from an RC (`X.Y.Z-rc.n → X.Y.Z`). Stable `patch`/`minor`/`major` results are unchanged. Version parsing now uses a regex that rejects malformed input instead of yielding `NaN` segments.
- **`next` dist-tag routing** (`scripts/publish.ts`): prerelease versions publish to `next`; stable versions continue publishing to `latest`.
- **Internal-dep pinning for prereleases**: internal `@aboutcircles/*` deps are declared as `"*"`, which npm resolves *excluding* prereleases — so an umbrella `@aboutcircles/sdk@x-rc.n` would otherwise pull the last stable sub-packages. Prerelease tarballs are published with those deps rewritten to the exact prerelease version; the on-disk change is reverted immediately after each publish, so committed source keeps `"*"`.
- **Workflow**: adds `prerelease` to the `version_type` choice; passes the input through a workflow environment variable for the bump step instead of inlining it.
- Adds unit tests (`scripts/release-tooling.test.ts`) for the version math and dep pinning, plus a `RELEASING.md` runbook. Side-effecting entry points are guarded behind `import.meta.main` so the pure functions are importable in tests.

## Why

Enables cutting release candidates to the `next` dist-tag for internal testing without touching `latest`. The change is additive and inert on the existing stable paths.

## Validated end-to-end

A `version_type: prerelease` dispatch published `0.1.58-rc.0`:
- `next` = `0.1.58-rc.0`; `latest` unchanged at `0.1.57`
- the umbrella package's internal `@aboutcircles/*` deps resolved to exactly `0.1.58-rc.0`, third-party ranges untouched

## Test plan

- [x] `bun test scripts/release-tooling.test.ts` — 17 tests (version math, finalize, dep pinning)
- [x] `bun run build` — all packages
