### PR TITLE
feat(rpc): forward quantizedMode, debugShowIntermediateSteps & simulatedConsentedAvatars in findPath

### DIFF
--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -112,9 +112,9 @@ const events = await rpc.query.events(
 - `getTotalBalanceV1(address, asTimeCircles?): Promise<bigint>` - Get total v1 Circles balance
 - `getTotalBalance(address, asTimeCircles?): Promise<bigint>` - Get total v2 Circles balance
 - `findPath(params): Promise<PathResponse>` - Calculate transfer path between addresses
-  - **params**: `{ from, to, targetFlow, useWrappedBalances?, fromTokens?, toTokens?, excludeFromTokens?, excludeToTokens?, simulatedBalances? }`
+  - **params**: `{ from, to, targetFlow, useWrappedBalances?, fromTokens?, toTokens?, excludeFromTokens?, excludeToTokens?, simulatedBalances?, simulatedTrusts?, simulatedConsentedAvatars?, maxTransfers?, quantizedMode?, debugShowIntermediateSteps? }`
   - All amounts are `bigint`, addresses normalized to lowercase
-  - Returns path with `flow` and `transfers` (all amounts as `bigint`)
+  - Returns path with `maxFlow` and `transfers` (all amounts as `bigint`); with `debugShowIntermediateSteps`, also `debug` with the pipeline stages
 
 ### Query Methods
 

--- a/packages/rpc/src/tests/normalizeFindPathParams.test.ts
+++ b/packages/rpc/src/tests/normalizeFindPathParams.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from 'bun:test';
+import { normalizeFindPathParams } from '../utils.js';
+import type { Address, FindPathParams } from '@aboutcircles/sdk-types';
+
+const FROM = '0x42cEDde51198D1773590311E2A340DC06B24cB37' as Address;
+const TO = '0x14c16ce62d26fd51582a646e2e30a3267b1e6d7e' as Address;
+
+const baseParams = (): FindPathParams => ({
+  from: FROM,
+  to: TO,
+  targetFlow: 1000n * 10n ** 18n,
+});
+
+describe('normalizeFindPathParams', () => {
+  test('maps the core fields', () => {
+    const result = normalizeFindPathParams(baseParams());
+
+    expect(result.Source).toBe(FROM.toLowerCase());
+    expect(result.Sink).toBe(TO.toLowerCase());
+    expect(result.TargetFlow).toBe('1000000000000000000000');
+  });
+
+  test('forwards quantizedMode and debugShowIntermediateSteps', () => {
+    const result = normalizeFindPathParams({
+      ...baseParams(),
+      quantizedMode: true,
+      debugShowIntermediateSteps: true,
+    });
+
+    expect(result.QuantizedMode).toBe(true);
+    expect(result.DebugShowIntermediateSteps).toBe(true);
+  });
+
+  test('normalizes simulatedConsentedAvatars to lowercase', () => {
+    const result = normalizeFindPathParams({
+      ...baseParams(),
+      simulatedConsentedAvatars: [FROM, TO],
+    });
+
+    expect(result.SimulatedConsentedAvatars).toEqual([FROM.toLowerCase(), TO.toLowerCase()]);
+  });
+
+  test('omits the new fields from the wire payload when unset', () => {
+    // Undefined values are dropped by JSON.stringify — the request stays backward compatible.
+    const serialized = JSON.parse(JSON.stringify(normalizeFindPathParams(baseParams())));
+
+    expect('QuantizedMode' in serialized).toBe(false);
+    expect('DebugShowIntermediateSteps' in serialized).toBe(false);
+    expect('SimulatedConsentedAvatars' in serialized).toBe(false);
+  });
+});

--- a/packages/rpc/src/utils.ts
+++ b/packages/rpc/src/utils.ts
@@ -90,7 +90,10 @@ export function normalizeFindPathParams(params: FindPathParams): Record<string, 
       Truster: normalizeAddress(trust.truster),
       Trustee: normalizeAddress(trust.trustee),
     })),
+    SimulatedConsentedAvatars: params.simulatedConsentedAvatars?.map(normalizeAddress),
     MaxTransfers: params.maxTransfers,
+    QuantizedMode: params.quantizedMode,
+    DebugShowIntermediateSteps: params.debugShowIntermediateSteps,
   };
 }
 

--- a/packages/types/src/pathfinding.ts
+++ b/packages/types/src/pathfinding.ts
@@ -37,7 +37,23 @@ export interface FindPathParams {
   excludeToTokens?: Address[];
   simulatedBalances?: SimulatedBalance[];
   simulatedTrusts?: SimulatedTrust[];
+  /**
+   * Addresses to treat as having consented to advanced usage (ERC-1155 operator
+   * approval). Affects which intermediate transfer paths are considered valid.
+   */
+  simulatedConsentedAvatars?: Address[];
   maxTransfers?: number;
+  /**
+   * When true, enforces 96 CRC quantization for sink-bound transfers (invitation
+   * module): each sink-bound transfer is exactly N × 96 CRC and the number of invites
+   * is derived from `targetFlow` (invites = targetFlow / 96 CRC).
+   */
+  quantizedMode?: boolean;
+  /**
+   * When true, the result includes {@link PathfindingResult.debug} with the pipeline
+   * transformation stages (raw paths → collapsed → router-inserted → sorted).
+   */
+  debugShowIntermediateSteps?: boolean;
 }
 
 /**
@@ -51,11 +67,28 @@ export interface TransferStep {
 }
 
 /**
+ * Debug pipeline stages, returned only when `debugShowIntermediateSteps` is set.
+ * Each stage lists the transfer steps at a point in the transformation pipeline.
+ */
+export interface PathfindingDebugStages {
+  /** Raw solver output, with token-pool intermediary nodes. */
+  rawPaths?: TransferStep[];
+  /** Token pools collapsed to direct avatar → avatar flows. */
+  collapsed?: TransferStep[];
+  /** Group mints routed (avatar → router → group). */
+  routerInserted?: TransferStep[];
+  /** Final on-chain execution order (collateral before mints). */
+  sorted?: TransferStep[];
+}
+
+/**
  * Result of pathfinding computation
  */
 export interface PathfindingResult {
   maxFlow: bigint;
   transfers: TransferStep[];
+  /** Pipeline transformation stages; present only when `debugShowIntermediateSteps` was set. */
+  debug?: PathfindingDebugStages;
 }
 
 /**


### PR DESCRIPTION
## Summary

`circlesV2_findPath` accepts `quantizedMode`, `debugShowIntermediateSteps` and `simulatedConsentedAvatars`, but `FindPathParams` and `normalizeFindPathParams` omitted them — so SDK callers had no way to set them. This adds the three fields and surfaces the debug pipeline stages on the result.

## Changes

- **`packages/types`** — add three optional fields to `FindPathParams`:
  - `quantizedMode?: boolean` — 96 CRC quantization for sink-bound transfers (invitation module); each sink transfer is exactly N × 96 CRC, invites derived from `targetFlow`.
  - `debugShowIntermediateSteps?: boolean` — include pipeline stages on the result.
  - `simulatedConsentedAvatars?: Address[]` — treat the given avatars as having consented to advanced usage.
  - Add `PathfindingDebugStages` and an optional `debug` field on `PathfindingResult` (raw → collapsed → router-inserted → sorted), populated only when `debugShowIntermediateSteps` is set.
- **`packages/rpc`** — `normalizeFindPathParams` maps the new fields to their PascalCase request keys (`QuantizedMode`, `DebugShowIntermediateSteps`, `SimulatedConsentedAvatars`). `simulatedConsentedAvatars` is address-normalized like the other address arrays. README param list updated.

## Backward compatibility

The fields are **optional** and only serialized when set — `undefined` keys are dropped by `JSON.stringify`, exactly like the existing possibly-undefined keys (`WithWrap`, `FromTokens`, …). Existing requests are byte-unchanged. The nested `debug` stages are handled by the existing recursive `parseStringsToBigInt` / `checksumAddresses` post-processing with no additional code. `AdvancedTransferOptions` and `findMaxFlow` inherit the new optionals for free.

## Tests & verification

- New `normalizeFindPathParams` unit test: forwarding of the new fields, address normalization, and the omitted-when-unset case. `bun test` → 4 pass.
- Full workspace build (`bun run build`) succeeds.
- Verified live against a public RPC through `rpc.pathfinder.findPath`:
  - `quantizedMode: true` → `maxFlow` is an exact 96 CRC multiple (1034 × 96 CRC).
  - `debugShowIntermediateSteps: true` → `debug` present with stages (4/2/2/2); `debug.sorted` deep-equals `transfers`.
  - `simulatedConsentedAvatars` → accepted, sound path returned.
  - Baseline (no new fields) unchanged.